### PR TITLE
Implemented support for PSCustomObject and new commands for Table management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -353,3 +353,6 @@ out/
 *.xml
 *.zip
 Test.ps1
+
+# Azurite files
+__*

--- a/Docs/Help/Add-AzDataTableEntity.md
+++ b/Docs/Help/Add-AzDataTableEntity.md
@@ -13,22 +13,14 @@ Add one or more entities to an Azure Table.
 
 ## SYNTAX
 
-### TableOperation
-
-```powershell
-Add-AzDataTableEntity -Entity <Hashtable[]> [-Force] -Context <AzDataTableContext> [-CreateTableIfNotExists]
- [<CommonParameters>]
 ```
-
-### Count
-
-```powershell
-Add-AzDataTableEntity -Context <AzDataTableContext> [-CreateTableIfNotExists] [<CommonParameters>]
+Add-AzDataTableEntity -Context <AzDataTableContext> -Entity <Object[]> [-Force] [-CreateTableIfNotExists]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-Add one or more entities to an Azure Table, provided as hashtables.
+Add one or more entities to an Azure Table, as an array of either Hashtables or PSObjects.
 
 ## EXAMPLES
 
@@ -56,33 +48,16 @@ Add multiple users to a table using a shared access signature URL, overwriting a
 
 ## PARAMETERS
 
-### -Entity
+### -Context
 
-The entities to add to the table.
+A context object created by New-AzDataTableContext, with authentication information for the table to operate on.
 
 ```yaml
-Type: Hashtable[]
-Parameter Sets: TableOperation
+Type: AzDataTableContext
+Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByValue)
-Accept wildcard characters: False
-```
-
-### -Force
-
-Overwrites provided entities if they exist.
-The same as running the command Update-AzDataTableEntity.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: TableOperation
-Aliases:
-
-Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -105,31 +80,50 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Context
+### -Entity
 
-A context object created by New-AzDataTableContext, with authentication information for the table to operate on.
+The entities to add to the table.
 
 ```yaml
-Type: AzDataTableContext
+Type: Object[]
 Parameter Sets: (All)
 Aliases:
 
 Required: True
 Position: Named
 Default value: None
-Accept pipeline input: True (ByPropertyName)
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Force
+
+Overwrites provided entities if they exist.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
-### System.Collections.Hashtable[]
+### System.Collections.Hashtable[] or System.Management.Automation.PSObject[]
+
+This cmdlet takes either an array of hashtables or psobjects as input to the Entity parameter, which can also be provided through the pipeline.
 
 ## OUTPUTS
+
+### System.Object
 
 ## NOTES
 

--- a/Docs/Help/Get-AzDataTableEntity.md
+++ b/Docs/Help/Get-AzDataTableEntity.md
@@ -14,16 +14,14 @@ Get one or more entities from an Azure Table.
 ## SYNTAX
 
 ### TableOperation (Default)
-
-```powershell
-Get-AzDataTableEntity [-Filter <String>] [-Property <String[]>] [-First <Int32>] [-Skip <Int32>]
- [-Sort <String[]>] -Context <AzDataTableContext> [-CreateTableIfNotExists] [<CommonParameters>]
+```
+Get-AzDataTableEntity -Context <AzDataTableContext> [-Filter <String>] [-Property <String[]>] [-First <Int32>]
+ [-Skip <Int32>] [-Sort <String[]>] [<CommonParameters>]
 ```
 
 ### Count
-
-```powershell
-Get-AzDataTableEntity [-Count] -Context <AzDataTableContext> [-CreateTableIfNotExists] [<CommonParameters>]
+```
+Get-AzDataTableEntity -Context <AzDataTableContext> [-Count] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -46,13 +44,22 @@ Get the user "Bobby Tables" from the table using a connection string.
 ### Example 2
 
 ```powershell
+PS C:\> $Context = New-AzDataTableContext -TableName $TableName -ConnectionString $ConnectionString
+PS C:\> $UserCount = Get-AzDataTableEntity -Filter "LastName eq 'Tables'" -Context $Context -Count
+```
+
+Use the Count parameter to get only the number of users matching the filter, using a connection string.
+
+### Example 3
+
+```powershell
 PS C:\> $Context = New-AzDataTableContext -TableName $TableName -ManagedIdentity -StorageAccountName $Name
 PS C:\> $UserEntities = Get-AzDataTableEntity -Sort 'Id','Age' -First 100 -Skip 500 -Context $Context
 ```
 
 Skipping the first 100 entities, get 500 entities sorted by id and age from the table using a managed identity for authorization.
 
-### Example 3
+### Example 4
 
 ```powershell
 PS C:\> $Context = New-AzDataTableContext -TableName $TableName -SharedAccessSignature $SAS
@@ -63,16 +70,32 @@ Get only the properties "FirstName" and "Age" for all entities found in the tabl
 
 ## PARAMETERS
 
-### -CreateTableIfNotExists
+### -Context
 
-If the table should be created if it does not exist.
+A context object created by New-AzDataTableContext, with authentication information for the table to operate on.
 
 ```yaml
-Type: SwitchParameter
+Type: AzDataTableContext
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Count
+
+Specifies to only get the number of matching entities in the table, and not the data itself.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Count
+Aliases:
+
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -96,22 +119,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Property
-
-One or several names of properties, to specify data to return for the entities.
-
-```yaml
-Type: String[]
-Parameter Sets: TableOperation
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -First
 
 Gets only the specified number of objects. Enter the number of objects to get.
@@ -120,6 +127,22 @@ Gets only the specified number of objects. Enter the number of objects to get.
 Type: Int32
 Parameter Sets: TableOperation
 Aliases: Top, Take
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Property
+
+One or several names of properties, to specify data to return for the entities.
+
+```yaml
+Type: String[]
+Parameter Sets: TableOperation
+Aliases:
 
 Required: False
 Position: Named
@@ -162,49 +185,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Count
-
-Specifies to only get the number of matching entities in the table, and not the data itself.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: Count
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Context
-
-A context object created by New-AzDataTableContext, with authentication information for the table to operate on.
-
-```yaml
-Type: AzDataTableContext
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
 ### CommonParameters
-
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
-### System.String
+### None
 
 ## OUTPUTS
 
-### System.Collections.Hashtable[]
+### System.Management.Automation.PSObject
 
 ## NOTES
 

--- a/Docs/Help/New-AzDataTable.md
+++ b/Docs/Help/New-AzDataTable.md
@@ -5,21 +5,21 @@ online version:
 schema: 2.0.0
 ---
 
-# Clear-AzDataTable
+# New-AzDataTable
 
 ## SYNOPSIS
 
-Clear all entities from an Azure Table.
+Create a new table.
 
 ## SYNTAX
 
 ```
-Clear-AzDataTable -Context <AzDataTableContext> [<CommonParameters>]
+New-AzDataTable -Context <AzDataTableContext> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-Clear all entities from an Azure Table.
+Create a new table.
 
 ## EXAMPLES
 
@@ -27,19 +27,10 @@ Clear all entities from an Azure Table.
 
 ```powershell
 PS C:\> $Context = New-AzDataTableContext -TableName $TableName -ConnectionString $ConnectionString
-PS C:\> Clear-AzDataTable -Context $Context
+PS C:\> New-AzDataTable -Context $Context
 ```
 
-Clear all entities from a table using a connection string.
-
-### Example 2
-
-```powershell
-PS C:\> $Context = New-AzDataTableContext -TableName $TableName -StorageAccountName $Name -ManagedIdentity
-PS C:\> Clear-AzDataTable $Context
-```
-
-Clear all entities from a table using a managed identity.
+Create a new table using a connection string for the storage account.
 
 ## PARAMETERS
 

--- a/Docs/Help/New-AzDataTableContext.md
+++ b/Docs/Help/New-AzDataTableContext.md
@@ -14,33 +14,28 @@ Creates a context object with authentication information for the table to operat
 ## SYNTAX
 
 ### ConnectionString
-
-```powershell
+```
 New-AzDataTableContext -TableName <String> -ConnectionString <String> [<CommonParameters>]
 ```
 
 ### SAS
-
-```powershell
+```
 New-AzDataTableContext -TableName <String> -SharedAccessSignature <Uri> [<CommonParameters>]
 ```
 
 ### Key
-
-```powershell
+```
 New-AzDataTableContext -TableName <String> -StorageAccountName <String> -StorageAccountKey <String>
  [<CommonParameters>]
 ```
 
 ### Token
-
-```powershell
+```
 New-AzDataTableContext -TableName <String> -StorageAccountName <String> -Token <String> [<CommonParameters>]
 ```
 
 ### ManagedIdentity
-
-```powershell
+```
 New-AzDataTableContext -TableName <String> -StorageAccountName <String> [-ManagedIdentity] [<CommonParameters>]
 ```
 
@@ -205,7 +200,6 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS

--- a/Docs/Help/Remove-AzDataTable.md
+++ b/Docs/Help/Remove-AzDataTable.md
@@ -5,21 +5,21 @@ online version:
 schema: 2.0.0
 ---
 
-# Clear-AzDataTable
+# Remove-AzDataTable
 
 ## SYNOPSIS
 
-Clear all entities from an Azure Table.
+Delete an existing table.
 
 ## SYNTAX
 
 ```
-Clear-AzDataTable -Context <AzDataTableContext> [<CommonParameters>]
+Remove-AzDataTable -Context <AzDataTableContext> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-Clear all entities from an Azure Table.
+Delete an existing table.
 
 ## EXAMPLES
 
@@ -27,19 +27,10 @@ Clear all entities from an Azure Table.
 
 ```powershell
 PS C:\> $Context = New-AzDataTableContext -TableName $TableName -ConnectionString $ConnectionString
-PS C:\> Clear-AzDataTable -Context $Context
+PS C:\> Remove-AzDataTable -Context $Context
 ```
 
-Clear all entities from a table using a connection string.
-
-### Example 2
-
-```powershell
-PS C:\> $Context = New-AzDataTableContext -TableName $TableName -StorageAccountName $Name -ManagedIdentity
-PS C:\> Clear-AzDataTable $Context
-```
-
-Clear all entities from a table using a managed identity.
+Remove an existing table using a connection string for the storage account.
 
 ## PARAMETERS
 

--- a/Docs/Help/Remove-AzDataTableEntity.md
+++ b/Docs/Help/Remove-AzDataTableEntity.md
@@ -8,27 +8,23 @@ schema: 2.0.0
 # Remove-AzDataTableEntity
 
 ## SYNOPSIS
+
 Remove one or more entities from an Azure Table.
 
 ## SYNTAX
 
-### TableOperation
 ```
-Remove-AzDataTableEntity -Entity <Hashtable[]> -Context <AzDataTableContext> [-CreateTableIfNotExists]
- [<CommonParameters>]
-```
-
-### Count
-```
-Remove-AzDataTableEntity -Context <AzDataTableContext> [-CreateTableIfNotExists] [<CommonParameters>]
+Remove-AzDataTableEntity -Context <AzDataTableContext> -Entity <Object[]> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Remove one or more entities from an Azure Table, based on PartitionKey and RowKey.
+
+Remove one or more entities from an Azure Table, as an array of either Hashtables or PSObjects, based on PartitionKey and RowKey.
 
 ## EXAMPLES
 
 ### Example 1
+
 ```powershell
 PS C:\> $Entity = @{ PartitionKey = 'Example'; RowKey = '1' }
 PS C:\> Remove-AzDataTableEntity -Entity $Entity -TableName $TableName -StorageAccountName $Name -StorageAccountKey $Key
@@ -37,6 +33,7 @@ PS C:\> Remove-AzDataTableEntity -Entity $Entity -TableName $TableName -StorageA
 Remove the entity with PartitionKey "Example" and RowKey "1", using the storage account name and an access key.
 
 ### Example 2
+
 ```powershell
 PS C:\> $UserEntity = Get-AzDataTableEntity -Filter "FirstName eq 'Bobby' and LastName eq 'Tables'" -TableName $TableName -ConnectionString $ConnectionString
 PS C:\> Remove-AzDataTableEntity -Entity $UserEntity -TableName $TableName -StorageAccountName $Name -StorageAccountKey $Key
@@ -45,6 +42,7 @@ PS C:\> Remove-AzDataTableEntity -Entity $UserEntity -TableName $TableName -Stor
 Get the user "Bobby Tables" from the table using a connection string, then remove the user using the storage account name and an access key.
 
 ### Example 3
+
 ```powershell
 PS C:\> $Users = Get-AzDataTableEntity -Filter "LastName eq 'Tables'" -TableName $TableName -ConnectionString $ConnectionString
 PS C:\> Remove-AzDataTableEntity -Entity $Users -TableName $TableName -StorageAccountName $Name -StorageAccountKey $Key
@@ -54,38 +52,9 @@ Gets all users with the last name "Tables" from the table using a connection str
 
 ## PARAMETERS
 
-### -Entity
-The entities to remove from the table.
-
-```yaml
-Type: Hashtable[]
-Parameter Sets: TableOperation
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByValue)
-Accept wildcard characters: False
-```
-
-### -CreateTableIfNotExists
-If the table should be created if it does not exist.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Context
-{{ Fill Context Description }}
+
+A context object created by New-AzDataTableContext, with authentication information for the table to operate on.
 
 ```yaml
 Type: AzDataTableContext
@@ -95,7 +64,23 @@ Aliases:
 Required: True
 Position: Named
 Default value: None
-Accept pipeline input: True (ByPropertyName)
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Entity
+
+The entities to remove from the table.
+
+```yaml
+Type: Object[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
@@ -104,9 +89,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.Collections.Hashtable[]
+### System.Collections.Hashtable[] or System.Management.Automation.PSObject[]
+
+This cmdlet takes either an array of hashtables or psobjects as input to the Entity parameter, which can also be provided through the pipeline.
 
 ## OUTPUTS
+
+### None
 
 ## NOTES
 

--- a/Docs/Help/Update-AzDataTableEntity.md
+++ b/Docs/Help/Update-AzDataTableEntity.md
@@ -8,23 +8,19 @@ schema: 2.0.0
 # Update-AzDataTableEntity
 
 ## SYNOPSIS
+
 Update one or more entities in an Azure Table.
 
 ## SYNTAX
 
-### TableOperation
 ```
-Update-AzDataTableEntity -Entity <Hashtable[]> -Context <AzDataTableContext> [-CreateTableIfNotExists]
- [<CommonParameters>]
-```
-
-### Count
-```
-Update-AzDataTableEntity -Context <AzDataTableContext> [-CreateTableIfNotExists] [<CommonParameters>]
+Update-AzDataTableEntity -Context <AzDataTableContext> -Entity <Object[]> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Update one or more entities already existing in an Azure Table.
+
+Update one or more entities already existing in an Azure Table, as an array of either Hashtables or PSObjects.
+
 For adding and overwriting, also see the command Add-AzDataTableEntity.
 
 The PartitionKey and RowKey cannot be updated.
@@ -32,6 +28,7 @@ The PartitionKey and RowKey cannot be updated.
 ## EXAMPLES
 
 ### Example 1
+
 ```powershell
 PS C:\> $UserEntity = Get-AzDataTableEntity -Filter "FirstName eq 'Bobby'" -TableName $TableName -ConnectionString $ConnectionString
 PS C:\> $UserEntity['LastName'] = 'Tables'
@@ -42,38 +39,9 @@ Update the last name of the user "Bobby" to "Tables" using a connection string.
 
 ## PARAMETERS
 
-### -Entity
-The entities to update in the table.
-
-```yaml
-Type: Hashtable[]
-Parameter Sets: TableOperation
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByValue)
-Accept wildcard characters: False
-```
-
-### -CreateTableIfNotExists
-If the table should be created if it does not exist.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Context
-{{ Fill Context Description }}
+
+A context object created by New-AzDataTableContext, with authentication information for the table to operate on.
 
 ```yaml
 Type: AzDataTableContext
@@ -83,7 +51,23 @@ Aliases:
 Required: True
 Position: Named
 Default value: None
-Accept pipeline input: True (ByPropertyName)
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Entity
+
+The entities to update in the table.
+
+```yaml
+Type: Object[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
@@ -92,9 +76,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.Collections.Hashtable[]
+### System.Collections.Hashtable[] or System.Management.Automation.PSObject[]
+
+This cmdlet takes either an array of hashtables or psobjects as input to the Entity parameter, which can also be provided through the pipeline.
 
 ## OUTPUTS
+
+### None
 
 ## NOTES
 

--- a/Source/AzBobbyTables.Core/AzBobbyTables.Core.csproj
+++ b/Source/AzBobbyTables.Core/AzBobbyTables.Core.csproj
@@ -10,6 +10,7 @@
 	  <PackageReference Include="Azure.Data.Tables" Version="12.8.0" />
 	  <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.5.22" />
 	  <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/Source/AzBobbyTables.Core/AzBobbyTables.Core.csproj
+++ b/Source/AzBobbyTables.Core/AzBobbyTables.Core.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>None</DebugType>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
     <RootNamespace>PipeHow.$(MSBuildProjectName.Replace(" ", "_").TrimEnd(".PS"))</RootNamespace>
   </PropertyGroup>
 

--- a/Source/AzBobbyTables.PS/AzBobbyTables.PS.csproj
+++ b/Source/AzBobbyTables.PS/AzBobbyTables.PS.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>None</DebugType>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
     <RootNamespace>PipeHow.$(MSBuildProjectName.Replace(" ", "_").TrimEnd(".PS"))</RootNamespace>
   </PropertyGroup>
 

--- a/Source/AzBobbyTables.PS/Cmdlets/AddAzDataTableEntity.cs
+++ b/Source/AzBobbyTables.PS/Cmdlets/AddAzDataTableEntity.cs
@@ -51,7 +51,7 @@ public class AddAzDataTableEntity : AzDataTableOperationCommand
                 tableService.AddEntitiesToTable(Entity.Cast<PSObject>(), Force.IsPresent);
                 break;
             default:
-                throw new ArgumentException($"Entities provided were not Hashtable or PSObject! Entity was {Entity.GetType().FullName}");
+                throw new ArgumentException($"Entities provided were not Hashtable or PSObject! First entity was of type {Entity.GetType().FullName}!");
         }
     }
 }

--- a/Source/AzBobbyTables.PS/Cmdlets/AddAzDataTableEntity.cs
+++ b/Source/AzBobbyTables.PS/Cmdlets/AddAzDataTableEntity.cs
@@ -1,5 +1,7 @@
 ﻿using PipeHow.AzBobbyTables.Validation;
+using System;
 using System.Collections;
+using System.Linq;
 using System.Management.Automation;
 
 namespace PipeHow.AzBobbyTables.Cmdlets;
@@ -7,24 +9,49 @@ namespace PipeHow.AzBobbyTables.Cmdlets;
 /// <summary>
 /// <para type="synopsis">Add one or more entities to an Azure Table.</para>
 /// </summary>
-[Cmdlet(VerbsCommon.Add, "AzDataTableEntity", DefaultParameterSetName = "TableOperation")]
+[Cmdlet(VerbsCommon.Add, "AzDataTableEntity")]
 public class AddAzDataTableEntity : AzDataTableOperationCommand
 {
     /// <summary>
+    /// <para type="description">The context used for the table, created with New-AzDataTableContext.</para>
+    /// </summary>
+    [Parameter(Mandatory = true)]
+    public AzDataTableContext Context { get; set; }
+
+    /// <summary>
     /// <para type="description">The entities to add to the table.</para>
     /// </summary>
-    [Parameter(Mandatory = true, ParameterSetName = "TableOperation", ValueFromPipeline = true)]
+    [Parameter(Mandatory = true, ValueFromPipeline = true)]
     [ValidateEntity]
-    public Hashtable[] Entity { get; set; }
+    [ValidateNotNullOrEmpty()]
+    public object[] Entity { get; set; }
 
     /// <summary>
     /// <para type="description">Overwrites provided entities if they exist.</para>
     /// </summary>
-    [Parameter(ParameterSetName = "TableOperation")]
+    [Parameter()]
     public SwitchParameter Force { get; set; }
+
+    /// <summary>
+    /// <para type="description">If the table should be created if it does not exist.</para>
+    /// </summary>
+    [Parameter()]
+    public SwitchParameter CreateTableIfNotExists { get; set; }
 
     /// <summary>
     /// The process step of the pipeline.
     /// </summary>
-    protected override void ProcessRecord() => tableService.AddEntitiesToTable(Entity, Force.IsPresent);
+    protected override void ProcessRecord() {
+        switch (Entity.First())
+        {
+            case Hashtable:
+                tableService.AddEntitiesToTable(Entity.Cast<Hashtable>(), Force.IsPresent);
+                break;
+            case PSObject:
+                tableService.AddEntitiesToTable(Entity.Cast<PSObject>(), Force.IsPresent);
+                break;
+            default:
+                throw new ArgumentException($"Entities provided were not Hashtable or PSObject! Entity was {Entity.GetType().FullName}");
+        }
+    }
 }

--- a/Source/AzBobbyTables.PS/Cmdlets/AzDataTableCommand.cs
+++ b/Source/AzBobbyTables.PS/Cmdlets/AzDataTableCommand.cs
@@ -16,11 +16,6 @@ public class AzDataTableCommand : PSCmdlet
 
     private protected CancellationTokenSource cancellationTokenSource = new();
 
-    /// <summary>
-    /// The process step of the pipeline.
-    /// </summary>
-    protected override void BeginProcessing() => WriteDebug("ParameterSetName: " + ParameterSetName);
-
     // Cancel any operations if user presses CTRL + C
     protected override void StopProcessing() => cancellationTokenSource.Cancel();
 }

--- a/Source/AzBobbyTables.PS/Cmdlets/GetAzDataTableEntity.cs
+++ b/Source/AzBobbyTables.PS/Cmdlets/GetAzDataTableEntity.cs
@@ -7,8 +7,16 @@ namespace PipeHow.AzBobbyTables.Cmdlets;
 /// <para type="synopsis">Get one or more entities from an Azure Table.</para>
 /// </summary>
 [Cmdlet(VerbsCommon.Get, "AzDataTableEntity", DefaultParameterSetName = "TableOperation")]
+[OutputType(typeof(PSObject))]
 public class GetAzDataTableEntity : AzDataTableOperationCommand
 {
+    /// <summary>
+    /// <para type="description">The context used for the table, created with New-AzDataTableContext.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "TableOperation")]
+    [Parameter(Mandatory = true, ParameterSetName = "Count")]
+    public AzDataTableContext Context { get; set; }
+
     /// <summary>
     /// <para type="description">The OData filter to use in the query.</para>
     /// </summary>
@@ -43,7 +51,7 @@ public class GetAzDataTableEntity : AzDataTableOperationCommand
     /// <summary>
     /// <para type="description">Specify that the output should only specify the number of entities.</para>
     /// </summary>
-    [Parameter(ParameterSetName = "Count", Mandatory = true)]
+    [Parameter(Mandatory = true, ParameterSetName = "Count")]
     public SwitchParameter Count { get; set; }
 
     protected override void BeginProcessing()

--- a/Source/AzBobbyTables.PS/Cmdlets/NewAzDataTable.cs
+++ b/Source/AzBobbyTables.PS/Cmdlets/NewAzDataTable.cs
@@ -3,10 +3,10 @@
 namespace PipeHow.AzBobbyTables.Cmdlets;
 
 /// <summary>
-/// <para type="synopsis">Clear all entities from an Azure Table.</para>
+/// <para type="synopsis">Create a new Azure Table.</para>
 /// </summary>
-[Cmdlet(VerbsCommon.Clear, "AzDataTable")]
-public class ClearAzDataTable : AzDataTableOperationCommand
+[Cmdlet(VerbsCommon.New, "AzDataTable")]
+public class NewAzDataTable : AzDataTableOperationCommand
 {
     /// <summary>
     /// <para type="description">The context used for the table, created with New-AzDataTableContext.</para>
@@ -14,5 +14,5 @@ public class ClearAzDataTable : AzDataTableOperationCommand
     [Parameter(Mandatory = true)]
     public AzDataTableContext Context { get; set; }
 
-    protected override void EndProcessing() => tableService.ClearTable();
+    // This command creates a table, logic to do so is in base class
 }

--- a/Source/AzBobbyTables.PS/Cmdlets/RemoveAzDataTable.cs
+++ b/Source/AzBobbyTables.PS/Cmdlets/RemoveAzDataTable.cs
@@ -3,10 +3,10 @@
 namespace PipeHow.AzBobbyTables.Cmdlets;
 
 /// <summary>
-/// <para type="synopsis">Clear all entities from an Azure Table.</para>
+/// <para type="synopsis">Removes a Azure Table.</para>
 /// </summary>
-[Cmdlet(VerbsCommon.Clear, "AzDataTable")]
-public class ClearAzDataTable : AzDataTableOperationCommand
+[Cmdlet(VerbsCommon.Remove, "AzDataTable")]
+public class RemoveAzDataTable : AzDataTableOperationCommand
 {
     /// <summary>
     /// <para type="description">The context used for the table, created with New-AzDataTableContext.</para>
@@ -14,5 +14,5 @@ public class ClearAzDataTable : AzDataTableOperationCommand
     [Parameter(Mandatory = true)]
     public AzDataTableContext Context { get; set; }
 
-    protected override void EndProcessing() => tableService.ClearTable();
+    protected override void EndProcessing() => tableService.RemoveTable();
 }

--- a/Source/AzBobbyTables.PS/Cmdlets/RemoveAzDataTableEntity.cs
+++ b/Source/AzBobbyTables.PS/Cmdlets/RemoveAzDataTableEntity.cs
@@ -40,7 +40,7 @@ public class RemoveAzDataTableEntity : AzDataTableOperationCommand
                 tableService.RemoveEntitiesFromTable(Entity.Cast<PSObject>());
                 break;
             default:
-                throw new ArgumentException($"Entities provided were not Hashtable or PSObject! Entity was {Entity.GetType().FullName}");
+                throw new ArgumentException($"Entities provided were not Hashtable or PSObject! First entity was of type {Entity.GetType().FullName}!");
         }
     }
 }

--- a/Source/AzBobbyTables.PS/Cmdlets/UpdateAzDataTableEntity.cs
+++ b/Source/AzBobbyTables.PS/Cmdlets/UpdateAzDataTableEntity.cs
@@ -40,7 +40,7 @@ public class UpdateAzDataTableEntity : AzDataTableOperationCommand
                 tableService.UpdateEntitiesInTable(Entity.Cast<PSObject>());
                 break;
             default:
-                throw new ArgumentException($"Entities provided were not Hashtable or PSObject! Entity was {Entity.GetType().FullName}");
+                throw new ArgumentException($"Entities provided were not Hashtable or PSObject! First entity was of type {Entity.GetType().FullName}!");
         }
     }
 }

--- a/Source/AzBobbyTables.PS/Cmdlets/UpdateAzDataTableEntity.cs
+++ b/Source/AzBobbyTables.PS/Cmdlets/UpdateAzDataTableEntity.cs
@@ -1,5 +1,7 @@
 ﻿using PipeHow.AzBobbyTables.Validation;
+using System;
 using System.Collections;
+using System.Linq;
 using System.Management.Automation;
 
 namespace PipeHow.AzBobbyTables.Cmdlets;
@@ -7,18 +9,38 @@ namespace PipeHow.AzBobbyTables.Cmdlets;
 /// <summary>
 /// <para type="synopsis">Update one or more entities in an Azure Table.</para>
 /// </summary>
-[Cmdlet(VerbsData.Update, "AzDataTableEntity", DefaultParameterSetName = "TableOperation")]
+[Cmdlet(VerbsData.Update, "AzDataTableEntity")]
 public class UpdateAzDataTableEntity : AzDataTableOperationCommand
 {
     /// <summary>
+    /// <para type="description">The context used for the table, created with New-AzDataTableContext.</para>
+    /// </summary>
+    [Parameter(Mandatory = true)]
+    public AzDataTableContext Context { get; set; }
+
+    /// <summary>
     /// <para type="description">The entities to update in the table.</para>
     /// </summary>
-    [Parameter(Mandatory = true, ParameterSetName = "TableOperation", ValueFromPipeline = true)]
+    [Parameter(Mandatory = true, ValueFromPipeline = true)]
+    [ValidateNotNullOrEmpty()]
     [ValidateEntity()]
-    public Hashtable[] Entity { get; set; }
+    public object[] Entity { get; set; }
 
     /// <summary>
     /// The process step of the pipeline.
     /// </summary>
-    protected override void ProcessRecord() => tableService.UpdateEntitiesInTable(Entity);
+    protected override void ProcessRecord()
+    {
+        switch (Entity.First())
+        {
+            case Hashtable:
+                tableService.UpdateEntitiesInTable(Entity.Cast<Hashtable>());
+                break;
+            case PSObject:
+                tableService.UpdateEntitiesInTable(Entity.Cast<PSObject>());
+                break;
+            default:
+                throw new ArgumentException($"Entities provided were not Hashtable or PSObject! Entity was {Entity.GetType().FullName}");
+        }
+    }
 }

--- a/Source/AzBobbyTables.PS/Manifest/AzBobbyTables.psd1
+++ b/Source/AzBobbyTables.PS/Manifest/AzBobbyTables.psd1
@@ -4,7 +4,7 @@
 RootModule = 'AzBobbyTables.PS.dll'
 
 # Version number of this module.
-ModuleVersion = '3.0.0'
+ModuleVersion = '3.1.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core')
@@ -71,6 +71,8 @@ CmdletsToExport = @(
     'Remove-AzDataTableEntity'
     'Update-AzDataTableEntity'
     'New-AzDataTableContext'
+    'Remove-AzDataTable'
+    'New-AzDataTable'
 )
 
 # Variables to export from this module

--- a/Source/AzBobbyTables.PS/Validation/ValidateEntity.cs
+++ b/Source/AzBobbyTables.PS/Validation/ValidateEntity.cs
@@ -1,24 +1,45 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 
 namespace PipeHow.AzBobbyTables.Validation;
 
+/// <summary>
+/// Validates that the first entity (as a model for all entities provided) has PartitionKey and RowKey.
+/// </summary>
 class ValidateEntityAttribute : ValidateArgumentsAttribute
 {
     protected override void Validate(object arguments, EngineIntrinsics engineIntrinsics)
     {
-        var entities = (IEnumerable<Hashtable>)arguments;
-
-        if (entities.Any(e => !e.ContainsKey("PartitionKey")))
+        // The input is an object array, but it must hold either Hashtables or PSObjects
+        var firstEntity = ((object[])arguments).First();
+        // Validate the first entity in the list
+        // First on type, then ensure correct values
+        switch (firstEntity)
         {
-            throw new ArgumentException("PartitionKey must be provided in the input entity in the correct casing!");
-        }
-        if (entities.Any(e => !e.ContainsKey("RowKey")))
-        {
-            throw new ArgumentException("RowKey must be provided in the input entity in the correct casing!");
+            case Hashtable hashtable:
+                if (!hashtable.ContainsKey("PartitionKey"))
+                {
+                    throw new ArgumentException("PartitionKey must be provided in the input hashtable entity in the correct casing!");
+                }
+                if (!hashtable.ContainsKey("RowKey"))
+                {
+                    throw new ArgumentException("RowKey must be provided in the input hashtable entity in the correct casing!");
+                }
+                break;
+            case PSObject psobject:
+                if (!psobject.Properties.Any(p => p.Name == "PartitionKey"))
+                {
+                    throw new ArgumentException("PartitionKey must be provided in the input psobject entity in the correct casing!");
+                }
+                if (!psobject.Properties.Any(p => p.Name == "RowKey"))
+                    {
+                    throw new ArgumentException("RowKey must be provided in the input psobject entity in the correct casing!");
+                }
+                break;
+            default:
+                throw new ArgumentException($"Input entities have to be either Hashtable or PSObject, first entity was {firstEntity.GetType().FullName}!");
         }
     }
 }

--- a/Tests/Add-AzDataTableEntity.Tests.ps1
+++ b/Tests/Add-AzDataTableEntity.Tests.ps1
@@ -10,14 +10,21 @@ BeforeDiscovery {
     
     # Get command from current test file name
     $Command = Get-Command ((Split-Path $PSCommandPath -Leaf) -replace '.Tests.ps1')
-    $ParameterTestCases = Get-CommonOperationCommandParameterTestCases -Command $Command
     $ParameterTestCases += @(
         @{
             Command       = $Command
-            Name          = 'Entity'
-            Type          = 'System.Collections.Hashtable[]'
+            Name          = 'Context'
+            Type          = 'PipeHow.AzBobbyTables.AzDataTableContext'
             ParameterSets = @(
-                @{ Name = 'TableOperation'; Mandatory = $true }
+                @{ Name = '__AllParameterSets'; Mandatory = $true }
+            )
+        }
+        @{
+            Command       = $Command
+            Name          = 'Entity'
+            Type          = 'System.Object[]'
+            ParameterSets = @(
+                @{ Name = '__AllParameterSets'; Mandatory = $true }
             )
         }
         @{
@@ -25,7 +32,15 @@ BeforeDiscovery {
             Name          = 'Force'
             Type          = 'System.Management.Automation.SwitchParameter'
             ParameterSets = @(
-                @{ Name = 'TableOperation'; Mandatory = $false }
+                @{ Name = '__AllParameterSets'; Mandatory = $false }
+            )
+        }
+        @{
+            Command       = $Command
+            Name          = 'CreateTableIfNotExists'
+            Type          = 'System.Management.Automation.SwitchParameter'
+            ParameterSets = @(
+                @{ Name = '__AllParameterSets'; Mandatory = $false }
             )
         }
     )

--- a/Tests/Clear-AzDataTable.Tests.ps1
+++ b/Tests/Clear-AzDataTable.Tests.ps1
@@ -10,7 +10,16 @@ BeforeDiscovery {
 
     # Get command from current test file name
     $Command = Get-Command ((Split-Path $PSCommandPath -Leaf) -replace '.Tests.ps1')
-    $ParameterTestCases = Get-CommonOperationCommandParameterTestCases -Command $Command
+    $ParameterTestCases = @(
+        @{
+            Command       = $Command
+            Name          = 'Context'
+            Type          = 'PipeHow.AzBobbyTables.AzDataTableContext'
+            ParameterSets = @(
+                @{ Name = '__AllParameterSets'; Mandatory = $true }
+            )
+        }
+    )
 }
 
 Describe 'Clear-AzDataTable' {

--- a/Tests/CommonTestLogic.ps1
+++ b/Tests/CommonTestLogic.ps1
@@ -4,28 +4,3 @@ function Invoke-ModuleReload {
     Remove-Module (Get-Module $Manifest -ListAvailable).Name -Force -ErrorAction SilentlyContinue
     Import-Module $Manifest -Force
 }
-
-function Get-CommonOperationCommandParameterTestCases {
-    param ($Command)
-    
-    return @(
-        @{
-            Command       = $Command
-            Name          = 'Context'
-            Type          = 'PipeHow.AzBobbyTables.AzDataTableContext'
-            ParameterSets = @(
-                @{ Name = 'TableOperation'; Mandatory = $true }
-                @{ Name = 'Count'; Mandatory = $true }
-            )
-        }
-        @{
-            Command       = $Command
-            Name          = 'CreateTableIfNotExists'
-            Type          = 'System.Management.Automation.SwitchParameter'
-            ParameterSets = @(
-                @{ Name = 'TableOperation'; Mandatory = $false }
-                @{ Name = 'Count'; Mandatory = $false }
-            )
-        }
-    )
-}

--- a/Tests/Get-AzDataTableEntity.Tests.ps1
+++ b/Tests/Get-AzDataTableEntity.Tests.ps1
@@ -10,8 +10,16 @@ BeforeDiscovery {
     
     # Get command from current test file name
     $Command = Get-Command ((Split-Path $PSCommandPath -Leaf) -replace '.Tests.ps1')
-    $ParameterTestCases = Get-CommonOperationCommandParameterTestCases -Command $Command
     $ParameterTestCases += @(
+        @{
+            Command       = $Command
+            Name          = 'Context'
+            Type          = 'PipeHow.AzBobbyTables.AzDataTableContext'
+            ParameterSets = @(
+                @{ Name = 'TableOperation'; Mandatory = $true }
+                @{ Name = 'Count'; Mandatory = $true }
+            )
+        }
         @{
             Command       = $Command
             Name          = 'Filter'

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -10,47 +10,27 @@ BeforeDiscovery {
 }
 
 Describe 'Integration Tests' -Tag 'Integration' {
-    Context 'Azurite' {
-        It 'is installed' {
-            { Get-Command 'azurite' -ErrorAction Stop } | Should -Not -Throw
-        }
-    }
-    Context 'module' {
-        BeforeAll {
-            $null = Start-ThreadJob { & azurite --silent --location $using:TestDrive } -Name 'AzuriteJob'
+    BeforeAll {
+        function Get-ComparableHash {
+            param($InputObject)
 
-            [hashtable[]]$Users = 1..4 | ForEach-Object {
-                @{
-                    'PartitionKey' = 'AzBobbyTables'
-                    'RowKey'       = "$_"
-                    'FirstName'    = "Bobby$_"
-                    'LastName'     = "Tables$_"
-                    'Id'           = "$_"
-                    'Value1'       = 1111111111
-                    'Prop1'        = 'Lorem ipsum.'
+            $PropertyHash = @{}
+
+            # Input is either hashtable or pscustomobject
+            if ($InputObject -is [hashtable]) {
+                $PropertyHash = $InputObject.GetEnumerator() | Sort-Object { $_.Key } | ForEach-Object -Begin {
+                    $Hash = [ordered]@{}
+                } -Process {
+                    $PropertyName = $_.Key
+                    $PropertyValue = $_.Value
+                    if (![string]::IsNullOrWhiteSpace($PropertyValue)) {
+                        $Hash.Add($PropertyName, $PropertyValue)
+                    }
+                } -End {
+                    Write-Output $Hash
                 }
             }
-            [hashtable[]]$UpdatedUsers = 1..4 | ForEach-Object {
-                @{
-                    'PartitionKey' = 'AzBobbyTables'
-                    'RowKey'       = "$_"
-                    'FirstName'    = 'Bobby'
-                    'LastName'     = 'Tables'
-                    'Id'           = "$_"
-                    'Value1'       = 2222222222
-                    'Prop1'        = 'Hello world.'
-                }
-            }
-            [hashtable[]]$UsersToRemove = 1..2 | ForEach-Object {
-                @{
-                    'PartitionKey' = 'AzBobbyTables'
-                    'RowKey'       = "$_"
-                }
-            }
-
-            function Get-ComparableHash {
-                param($InputObject)
-
+            elseif ($InputObject -is [pscustomobject]) {
                 $PropertyHash = $InputObject | Get-Member -MemberType NoteProperty | Sort-Object { $_.Name } | ForEach-Object -Begin {
                     $Hash = [ordered]@{}
                 } -Process {
@@ -62,49 +42,216 @@ Describe 'Integration Tests' -Tag 'Integration' {
                 } -End {
                     Write-Output $Hash
                 }
-            
-                return [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(($PropertyHash.Keys | Sort-Object | ForEach-Object {
-                    $PropertyHash[$_]
-                }) -join ''))
             }
+            
+            # Output hash of object
+            [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(($PropertyHash.Keys | Sort-Object | ForEach-Object {
+                $PropertyHash[$_]
+            }) -join ''))
+        }
+    }
+
+    Context 'Azurite' {
+        It 'is installed' {
+            { Get-Command 'azurite' -ErrorAction Stop } | Should -Not -Throw
+        }
+    }
+
+    Context 'hashtable' {
+        BeforeAll {
+            $null = Start-ThreadJob { & azurite --silent --location "$using:TestDrive\hashtable" } -Name 'AzuriteJob'
+
+            $UsersHashtable = 1..4 | ForEach-Object {
+                @{
+                    'PartitionKey' = 'AzBobbyTables'
+                    'RowKey'       = "$_"
+                    'FirstName'    = "Bobby$_"
+                    'LastName'     = "Tables$_"
+                    'Id'           = "$_"
+                    'Value1'       = 1111111111
+                    'Prop1'        = 'Lorem ipsum.'
+                }
+            }
+            $UpdatedUsersHashtable = 1..4 | ForEach-Object {
+                @{
+                    'PartitionKey' = 'AzBobbyTables'
+                    'RowKey'       = "$_"
+                    'FirstName'    = 'Bobby'
+                    'LastName'     = 'Tables'
+                    'Id'           = "$_"
+                    'Value1'       = 2222222222
+                    'Prop1'        = 'Hello world.'
+                }
+            }
+            $UsersToRemoveHashtable = 1..2 | ForEach-Object {
+                @{
+                    'PartitionKey' = 'AzBobbyTables'
+                    'RowKey'       = "$_"
+                }
+            }
+
+            $TableName = 'AzBobbyTablesHashtable'
         }
 
-        It 'can create table and add data' {
-            $Context = New-AzDataTableContext -TableName 'AzBobbyTables' -ConnectionString 'UseDevelopmentStorage=true'
-            Add-AzDataTableEntity -Context $Context -Entity $Users -CreateTableIfNotExists | Should -BeNullOrEmpty
-            $Result = Get-AzDataTableEntity -Context $Context | ForEach-Object { [pscustomobject]$_ } | Select-Object -ExcludeProperty 'Timestamp', 'ETag'
+        It 'can create table' {
+            $Context = New-AzDataTableContext -TableName $TableName -ConnectionString 'UseDevelopmentStorage=true'
+            New-AzDataTable -Context $Context | Should -BeNullOrEmpty
+        }
+
+        It 'can add data' {
+            $Context = New-AzDataTableContext -TableName $TableName -ConnectionString 'UseDevelopmentStorage=true'
+            Add-AzDataTableEntity -Context $Context -Entity $UsersHashtable | Should -BeNullOrEmpty
+            $Result = Get-AzDataTableEntity -Context $Context | Select-Object -ExcludeProperty 'Timestamp','ETag'
             foreach ($User in $Result) {
-                $ExpectedData = Get-ComparableHash ([pscustomobject]($Users | Where-Object { $_['Id'] -eq $User.Id }))
+                $ExpectedData = Get-ComparableHash ($UsersHashtable | Where-Object { $_['Id'] -eq $User.Id })
                 Get-ComparableHash $User | Should -Be $ExpectedData
             }
         }
 
         It 'can update entities' {
-            $Context = New-AzDataTableContext -TableName 'AzBobbyTables' -ConnectionString 'UseDevelopmentStorage=true'
-            Update-AzDataTableEntity -Context $Context -Entity $UpdatedUsers | Should -BeNullOrEmpty
-            $Result = Get-AzDataTableEntity -Context $Context | ForEach-Object { [pscustomobject]$_ } | Select-Object -ExcludeProperty 'Timestamp', 'ETag'
+            $Context = New-AzDataTableContext -TableName $TableName -ConnectionString 'UseDevelopmentStorage=true'
+            Update-AzDataTableEntity -Context $Context -Entity $UpdatedUsersHashtable | Should -BeNullOrEmpty
+            $Result = Get-AzDataTableEntity -Context $Context | Select-Object -ExcludeProperty 'Timestamp','ETag'
             foreach ($User in $Result) {
-                $ExpectedData = Get-ComparableHash ([pscustomobject]($UpdatedUsers | Where-Object { $_['Id'] -eq $User.Id }))
+                $ExpectedData = Get-ComparableHash ($UpdatedUsersHashtable | Where-Object { $_['Id'] -eq $User.Id })
                 Get-ComparableHash $User | Should -Be $ExpectedData
             }
         }
 
         It 'can remove entities' {
-            $Context = New-AzDataTableContext -TableName 'AzBobbyTables' -ConnectionString 'UseDevelopmentStorage=true'
-            Remove-AzDataTableEntity -Context $Context -Entity $UsersToRemove | Should -BeNullOrEmpty
-            (Get-AzDataTableEntity -Context $Context).Count | Should -BeExactly ($Users.Count - $UsersToRemove.Count)
+            $Context = New-AzDataTableContext -TableName $TableName -ConnectionString 'UseDevelopmentStorage=true'
+            Remove-AzDataTableEntity -Context $Context -Entity $UsersToRemoveHashtable | Should -BeNullOrEmpty
+            (Get-AzDataTableEntity -Context $Context).Count | Should -BeExactly ($UsersHashtable.Count - $UsersToRemoveHashtable.Count)
         }
 
         It 'can clear table' {
-            $Context = New-AzDataTableContext -TableName 'AzBobbyTables' -ConnectionString 'UseDevelopmentStorage=true'
+            $Context = New-AzDataTableContext -TableName $TableName -ConnectionString 'UseDevelopmentStorage=true'
             Get-AzDataTableEntity -Context $Context | Should -Not -BeNullOrEmpty
             Clear-AzDataTable -Context $Context
             Get-AzDataTableEntity -Context $Context | Should -BeNullOrEmpty
         }
 
+        It 'can remove table' {
+            $Context = New-AzDataTableContext -TableName $TableName -ConnectionString 'UseDevelopmentStorage=true'
+            Remove-AzDataTable -Context $Context | Should -BeNullOrEmpty
+        }
+
+        It 'cannot use removed table' {
+            $Context = New-AzDataTableContext -TableName $TableName -ConnectionString 'UseDevelopmentStorage=true'
+            { Get-AzDataTableEntity -Context $Context } | Should -Throw
+        }
+
+        It 'can add data to new table when forcing creation' {
+            $Context = New-AzDataTableContext -TableName $TableName -ConnectionString 'UseDevelopmentStorage=true'
+            Add-AzDataTableEntity -Context $Context -Entity $UsersHashtable -CreateTableIfNotExists | Should -BeNullOrEmpty
+            $Result = Get-AzDataTableEntity -Context $Context | Select-Object -ExcludeProperty 'Timestamp','ETag'
+            foreach ($User in $Result) {
+                $ExpectedData = Get-ComparableHash ($UsersHashtable | Where-Object { $_['Id'] -eq $User.Id })
+                Get-ComparableHash $User | Should -Be $ExpectedData
+            }
+        }
+
         AfterAll {
-            $Context = New-AzDataTableContext -TableName 'AzBobbyTables' -ConnectionString 'UseDevelopmentStorage=true'
-            Clear-AzDataTable -Context $Context -ErrorAction SilentlyContinue
+            Stop-Job -Name 'AzuriteJob'
+            Remove-Job -Name 'AzuriteJob'
+        }
+    }
+    
+    Context 'psobject' {
+        BeforeAll {
+            $null = Start-ThreadJob { & azurite --silent --location "$using:TestDrive\psobject" } -Name 'AzuriteJob'
+
+            $UsersPSObjects = 1..4 | ForEach-Object {
+                [pscustomobject]@{
+                    'PartitionKey' = 'AzBobbyTables'
+                    'RowKey'       = "$_"
+                    'FirstName'    = "Bobby$_"
+                    'LastName'     = "Tables$_"
+                    'Id'           = "$_"
+                    'Value1'       = 1111111111
+                    'Prop1'        = 'Lorem ipsum.'
+                }
+            }
+            $UpdatedUsersPSObjects = 1..4 | ForEach-Object {
+                [pscustomobject]@{
+                    'PartitionKey' = 'AzBobbyTables'
+                    'RowKey'       = "$_"
+                    'FirstName'    = 'Bobby'
+                    'LastName'     = 'Tables'
+                    'Id'           = "$_"
+                    'Value1'       = 2222222222
+                    'Prop1'        = 'Hello world.'
+                }
+            }
+            $UsersToRemovePSObjects = 1..2 | ForEach-Object {
+                [pscustomobject]@{
+                    'PartitionKey' = 'AzBobbyTables'
+                    'RowKey'       = "$_"
+                }
+            }
+
+            $TableName = 'AzBobbyTablesPSObject'
+        }
+
+        It 'can create table' {
+            $Context = New-AzDataTableContext -TableName $TableName -ConnectionString 'UseDevelopmentStorage=true'
+            New-AzDataTable -Context $Context | Should -BeNullOrEmpty
+        }
+
+        It 'can add data' {
+            $Context = New-AzDataTableContext -TableName $TableName -ConnectionString 'UseDevelopmentStorage=true'
+            Add-AzDataTableEntity -Context $Context -Entity $UsersPSObjects | Should -BeNullOrEmpty
+            $Result = Get-AzDataTableEntity -Context $Context | Select-Object -ExcludeProperty 'Timestamp', 'ETag'
+            foreach ($User in $Result) {
+                $ExpectedData = Get-ComparableHash ($UsersPSObjects | Where-Object { $_.Id -eq $User.Id })
+                Get-ComparableHash $User | Should -Be $ExpectedData
+            }
+        }
+
+        It 'can update entities' {
+            $Context = New-AzDataTableContext -TableName $TableName -ConnectionString 'UseDevelopmentStorage=true'
+            Update-AzDataTableEntity -Context $Context -Entity $UpdatedUsersPSObjects | Should -BeNullOrEmpty
+            $Result = Get-AzDataTableEntity -Context $Context | Select-Object -ExcludeProperty 'Timestamp', 'ETag'
+            foreach ($User in $Result) {
+                $ExpectedData = Get-ComparableHash ($UpdatedUsersPSObjects | Where-Object { $_.Id -eq $User.Id })
+                Get-ComparableHash $User | Should -Be $ExpectedData
+            }
+        }
+
+        It 'can remove entities' {
+            $Context = New-AzDataTableContext -TableName $TableName -ConnectionString 'UseDevelopmentStorage=true'
+            Remove-AzDataTableEntity -Context $Context -Entity $UsersToRemovePSObjects | Should -BeNullOrEmpty
+            (Get-AzDataTableEntity -Context $Context).Count | Should -BeExactly ($UsersPSObjects.Count - $UsersToRemovePSObjects.Count)
+        }
+
+        It 'can clear table' {
+            $Context = New-AzDataTableContext -TableName $TableName -ConnectionString 'UseDevelopmentStorage=true'
+            Get-AzDataTableEntity -Context $Context | Should -Not -BeNullOrEmpty
+            Clear-AzDataTable -Context $Context
+            Get-AzDataTableEntity -Context $Context | Should -BeNullOrEmpty
+        }
+
+        It 'can remove table' {
+            $Context = New-AzDataTableContext -TableName $TableName -ConnectionString 'UseDevelopmentStorage=true'
+            Remove-AzDataTable -Context $Context | Should -BeNullOrEmpty
+        }
+
+        It 'cannot use removed table' {
+            $Context = New-AzDataTableContext -TableName $TableName -ConnectionString 'UseDevelopmentStorage=true'
+            { Get-AzDataTableEntity -Context $Context } | Should -Throw
+        }
+
+        It 'can add data to new table when forcing creation' {
+            $Context = New-AzDataTableContext -TableName $TableName -ConnectionString 'UseDevelopmentStorage=true'
+            Add-AzDataTableEntity -Context $Context -Entity $UsersPSObjects -CreateTableIfNotExists | Should -BeNullOrEmpty
+            $Result = Get-AzDataTableEntity -Context $Context | Select-Object -ExcludeProperty 'Timestamp', 'ETag'
+            foreach ($User in $Result) {
+                $ExpectedData = Get-ComparableHash ($UsersPSObjects | Where-Object { $_.Id -eq $User.Id })
+                Get-ComparableHash $User | Should -Be $ExpectedData
+            }
+        }
+
+        AfterAll {
             Stop-Job -Name 'AzuriteJob'
             Remove-Job -Name 'AzuriteJob'
         }

--- a/Tests/Module.Tests.ps1
+++ b/Tests/Module.Tests.ps1
@@ -55,6 +55,10 @@ Describe "$ModuleName" {
         It 'has parameter Context for all commands except New-AzDataTableContext' {
             Get-Command -Module $ModuleName | Where-Object Name -NE 'New-AzDataTableContext' | Should -HaveParameter 'Context'
         }
+
+        It 'has no help file with empty documentation sections' {
+            Get-ChildItem "$RootDirectory\Docs\Help\*.md" | Select-String '{{|}}' | Should -BeNullOrEmpty
+        }
         
         It 'has command <Command> defined in file in the correct directory' -TestCases $CommandTestCases {
             $CommandFileName = $Command -replace '-'

--- a/Tests/New-AzDataTable.Tests.ps1
+++ b/Tests/New-AzDataTable.Tests.ps1
@@ -10,15 +10,7 @@ BeforeDiscovery {
 
     # Get command from current test file name
     $Command = Get-Command ((Split-Path $PSCommandPath -Leaf) -replace '.Tests.ps1')
-    $ParameterTestCases += @(
-        @{
-            Command       = $Command
-            Name          = 'Entity'
-            Type          = 'System.Object[]'
-            ParameterSets = @(
-                @{ Name = '__AllParameterSets'; Mandatory = $true }
-            )
-        }
+    $ParameterTestCases = @(
         @{
             Command       = $Command
             Name          = 'Context'
@@ -30,7 +22,7 @@ BeforeDiscovery {
     )
 }
 
-Describe 'Remove-AzDataTableEntity' {
+Describe 'New-AzDataTable' {
     Context 'parameters' {
 
         It 'only has expected parameters' -TestCases @{ Command = $Command ; Parameters = $ParameterTestCases.Name } {

--- a/Tests/Remove-AzDataTable.Tests.ps1
+++ b/Tests/Remove-AzDataTable.Tests.ps1
@@ -10,15 +10,7 @@ BeforeDiscovery {
 
     # Get command from current test file name
     $Command = Get-Command ((Split-Path $PSCommandPath -Leaf) -replace '.Tests.ps1')
-    $ParameterTestCases += @(
-        @{
-            Command       = $Command
-            Name          = 'Entity'
-            Type          = 'System.Object[]'
-            ParameterSets = @(
-                @{ Name = '__AllParameterSets'; Mandatory = $true }
-            )
-        }
+    $ParameterTestCases = @(
         @{
             Command       = $Command
             Name          = 'Context'
@@ -30,7 +22,7 @@ BeforeDiscovery {
     )
 }
 
-Describe 'Remove-AzDataTableEntity' {
+Describe 'Remove-AzDataTable' {
     Context 'parameters' {
 
         It 'only has expected parameters' -TestCases @{ Command = $Command ; Parameters = $ParameterTestCases.Name } {

--- a/Tests/Update-AzDataTableEntity.Tests.ps1
+++ b/Tests/Update-AzDataTableEntity.Tests.ps1
@@ -10,14 +10,21 @@ BeforeDiscovery {
 
     # Get command from current test file name
     $Command = Get-Command ((Split-Path $PSCommandPath -Leaf) -replace '.Tests.ps1')
-    $ParameterTestCases = Get-CommonOperationCommandParameterTestCases -Command $Command
     $ParameterTestCases += @(
         @{
             Command       = $Command
-            Name          = 'Entity'
-            Type          = 'System.Collections.Hashtable[]'
+            Name          = 'Context'
+            Type          = 'PipeHow.AzBobbyTables.AzDataTableContext'
             ParameterSets = @(
-                @{ Name = 'TableOperation'; Mandatory = $true }
+                @{ Name = '__AllParameterSets'; Mandatory = $true }
+            )
+        }
+        @{
+            Command       = $Command
+            Name          = 'Entity'
+            Type          = 'System.Object[]'
+            ParameterSets = @(
+                @{ Name = '__AllParameterSets'; Mandatory = $true }
             )
         }
     )

--- a/build.ps1
+++ b/build.ps1
@@ -73,8 +73,10 @@ if ($Version) {
     Update-ModuleManifest -Path "$OutDir/$ModuleName.psd1" -ModuleVersion $SemVer -Prerelease $PreReleaseTag
 }
 
-New-ExternalHelp -Path "$PSScriptRoot\Docs\Help" -OutputPath $OutDocs
-
 Pop-Location
 
-& .\Tests\TestRunner.ps1 -ModuleLoadPath "$OutDir\$ModuleName.psd1" -SkipIntegration:$SkipIntegrationTests.IsPresent
+# Run markdown file updates and tests in separate PowerShell sessions to avoid module load assembly locking
+& pwsh -c "Import-Module '$OutDir\$ModuleName.psd1'; Update-MarkdownHelpModule -Path '$PSScriptRoot\Docs\Help'"
+& pwsh -c ".\Tests\TestRunner.ps1 -ModuleLoadPath '$OutDir\$ModuleName.psd1' -SkipIntegration:`$$($SkipIntegrationTests.IsPresent)"
+
+New-ExternalHelp -Path "$PSScriptRoot\Docs\Help" -OutputPath $OutDocs


### PR DESCRIPTION
- Closes #12 
  - `Get-AzDataTableEntity` now returns `PSCustomObject`
  - `-Entity` parameter now accepts either `Hashtable[]` or `PSObject` (`PSCustomObject`)
- Changed structure of inheritance of parameters and parameter sets
- Added commands `New-AzDataTable` and `Remove-AzDataTable`
- Added tests for new commands, missing documentation and for `Entity` parameter data types
- Removed `-CreateTableIfNotExists` from all commands except `Add-AzDataTableEntity`
- Removed debug symbol file output when building
- Added Azurite files to `.gitignore`