### PR TITLE
Share http client transport across all table client instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on and uses the types of changes according to [Keep a Change
 
 ## [Unreleased]
 
+### Changed
+
+- Share a single HttpClient across all TableClient/TableServiceClient instances via HttpClientTransport, enabling TCP connection pooling and reducing socket churn in high-concurrency scenarios
+
 ## [3.4.2] - 2026-03-30
 
 ### Fixed

--- a/source/AzBobbyTables.Core/AzDataTableService.cs
+++ b/source/AzBobbyTables.Core/AzDataTableService.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 using System.Threading;
+using Azure.Core.Pipeline;
+using System.Net.Http;
 
 namespace PipeHow.AzBobbyTables.Core;
 
@@ -25,6 +27,21 @@ public enum OperationTypeEnum
 
 public class AzDataTableService
 {
+    /// <summary>
+    /// Shared HttpClient used by all TableClient/TableServiceClient instances.
+    /// Connection pooling is handled by the runtime's SocketsHttpHandler (.NET Core 3.1+).
+    /// This eliminates per-cmdlet TCP connection creation.
+    /// </summary>
+    private static readonly HttpClient SharedHttpClient = new HttpClient();
+    private static readonly HttpClientTransport SharedTransport = new HttpClientTransport(SharedHttpClient);
+
+    private static TableClientOptions CreateSharedOptions()
+    {
+        var options = new TableClientOptions();
+        options.Transport = SharedTransport;
+        return options;
+    }
+
     private TableClient? TableClient { get; set; }
     private TableServiceClient? TableServiceClient { get; set; }
 
@@ -76,11 +93,11 @@ public class AzDataTableService
         {
             var dataTableService = new AzDataTableService(cancellationToken);
 
-            TableServiceClient serviceClient = new(connectionString);
+            TableServiceClient serviceClient = new(connectionString, CreateSharedOptions());
 
             if (tableName is not null)
             {
-                TableClient client = new(connectionString, tableName);
+                TableClient client = new(connectionString, tableName, CreateSharedOptions());
 
                 if (createIfNotExists && !string.IsNullOrWhiteSpace(tableName))
                 {
@@ -108,11 +125,11 @@ public class AzDataTableService
 
             var sasCredential = new TableSharedKeyCredential(storageAccountName, storageAccountKey);
 
-            TableServiceClient serviceClient = new(tableEndpoint, sasCredential);
+            TableServiceClient serviceClient = new(tableEndpoint, sasCredential, CreateSharedOptions());
 
             if (tableName is not null)
             {
-                TableClient client = new(tableEndpoint, tableName, sasCredential);
+                TableClient client = new(tableEndpoint, tableName, sasCredential, CreateSharedOptions());
 
                 if (createIfNotExists && !string.IsNullOrWhiteSpace(tableName))
                 {
@@ -138,11 +155,11 @@ public class AzDataTableService
             var dataTableService = new AzDataTableService(cancellationToken);
             var tableEndpoint = new Uri($"https://{storageAccountName}.table.core.windows.net/{tableName}");
 
-            TableServiceClient serviceClient = new(tableEndpoint, new ExternalTokenCredential(token, DateTimeOffset.Now.Add(TimeSpan.FromHours(1))));
+            TableServiceClient serviceClient = new(tableEndpoint, new ExternalTokenCredential(token, DateTimeOffset.Now.Add(TimeSpan.FromHours(1))), CreateSharedOptions());
 
             if (tableName is not null)
             {
-                TableClient client = new(tableEndpoint, tableName, new ExternalTokenCredential(token, DateTimeOffset.Now.Add(TimeSpan.FromHours(1))));
+                TableClient client = new(tableEndpoint, tableName, new ExternalTokenCredential(token, DateTimeOffset.Now.Add(TimeSpan.FromHours(1))), CreateSharedOptions());
 
                 if (createIfNotExists && !string.IsNullOrWhiteSpace(tableName))
                 {
@@ -179,10 +196,10 @@ public class AzDataTableService
                 sasUrl = new Uri($"{urlParts.First().TrimEnd('/')}/{tableName}?{urlParts.Last()}");
             }
 
-            TableServiceClient serviceClient = new TableServiceClient(baseUrl, sasCredential);
+            TableServiceClient serviceClient = new TableServiceClient(baseUrl, sasCredential, CreateSharedOptions());
             if (tableName is not null)
             {
-                TableClient client = new(sasUrl, sasCredential);
+                TableClient client = new(sasUrl, sasCredential, CreateSharedOptions());
 
                 if (createIfNotExists && !string.IsNullOrWhiteSpace(tableName))
                 {


### PR DESCRIPTION
Each cmdlet call (Get-AzDataTableEntity, Add-AzDataTableEntity, etc.) creates a new TableClient and TableServiceClient in BeginProcessing. Each of these gets its own HTTP pipeline and opens fresh TCP connections to the storage endpoint.

In high-throughput scenarios (e.g. Azure Functions with multiple concurrent runspaces), this leads to connection churn and TIME_WAIT socket accumulation. On Azure App Service plans without VNet integration, this contributes to SNAT port exhaustion (128 port limit per instance).

This adds a static shared HttpClient and HttpClientTransport that all TableClient/TableServiceClient instances use via TableClientOptions.

### Changed
- AzDataTableService now shares a single HttpClient across all TableClient and TableServiceClient instances via HttpClientTransport, enabling TCP connection pooling.

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or failed tests.
- [x] Markdown help added/updated.
- [x] Unit tests added/updated.