### PR TITLE
fix: remove unnecessary ref input from checkout steps in workflows

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -11,7 +11,6 @@ runs:
   steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ github.head_ref }}
         fetch-depth: 0
         
     - name: Download Build Artifact

--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -31,7 +31,6 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
-        ref: ${{ github.head_ref }}
         fetch-depth: 0
 
     - name: 'Build and Package Module'
@@ -51,7 +50,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: 'Test Module'
@@ -73,7 +71,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: 'Publish Test Results'

--- a/.github/workflows/PublishReleaseAndModule.yml
+++ b/.github/workflows/PublishReleaseAndModule.yml
@@ -16,7 +16,6 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
-        ref: ${{ github.head_ref }}
         fetch-depth: 0
 
     - name: 'Build and Package Module'
@@ -36,7 +35,6 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
-        ref: ${{ github.head_ref }}
         fetch-depth: 0
 
     - name: 'Test Module'


### PR DESCRIPTION
Closes #123 to ensure that external forks can also run pipelines when making PRs