### PR TITLE
perf: batch pipeline entities into single transactions and reduce hot-path allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on and uses the types of changes according to [Keep a Change
 
 ## [Unreleased]
 
+### Changed
+
+- `Add-`, `Remove-` and `Update-AzDataTableEntity` now collect entities from the pipeline and submit them as batched transactions when the pipeline completes, instead of one transaction per pipeline record.
+- `Get-AzDataTableEntity` passes a page-size hint to the service when `-First` is used without `-Sort`, so the service returns a bounded page instead of a full page truncated client-side.
+- `-Count` no longer projects full PSObjects in order to count them.
+- Entity validation and converter selection now run in a single pass.
+
+### Removed
+
+- Dependency on `System.Linq.Async`; queries now run synchronously.
+
 ## [3.6.0] - 2026-07-01
 
 ### Added

--- a/source/AzBobbyTables.Core/AzBobbyTables.Core.csproj
+++ b/source/AzBobbyTables.Core/AzBobbyTables.Core.csproj
@@ -12,7 +12,6 @@
   <ItemGroup>
 	  <PackageReference Include="Azure.Data.Tables" Version="12.11.0" />
 	  <PackageReference Include="Microsoft.VisualStudio.Threading" Version="18.7.23" />
-	  <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/source/AzBobbyTables.Core/AzDataTableService.cs
+++ b/source/AzBobbyTables.Core/AzDataTableService.cs
@@ -107,6 +107,19 @@ public class AzDataTableService
         return options;
     }
 
+    /// <summary>
+    /// The maximum number of entities Azure Table Storage accepts in a single transaction.
+    /// </summary>
+    private const int MaxTransactionSize = 100;
+
+    /// <summary>
+    /// Creates the transaction list, presized when the source count is known to avoid regrowing it.
+    /// </summary>
+    private static List<TableTransactionAction> CreateTransactionList(IEnumerable<object> entities) =>
+        entities is ICollection<object> collection
+            ? new List<TableTransactionAction>(collection.Count)
+            : new List<TableTransactionAction>();
+
     private TableClient? TableClient { get; set; }
     private TableServiceClient? TableServiceClient { get; set; }
 
@@ -329,7 +342,7 @@ public class AzDataTableService
 
         try
         {
-            var transactions = new List<TableTransactionAction>();
+            var transactions = CreateTransactionList(entities);
             var registry = EntityConverterRegistry.Instance;
 
             var tableEntities = entities.Select(entity =>
@@ -341,12 +354,19 @@ public class AzDataTableService
                     throw new ArgumentException($"Unsupported entity type '{entity.GetType().FullName}'. Supported types are: {supportedTypes}");
                 }
 
-                if (!converter.ValidateEntity(entity))
+                // Convert first, then check the keys on the result. ValidateEntity walked every
+                // key of the input looking for the two required ones, so each entity was
+                // traversed twice. The converted entity is dictionary backed, and ContainsKey
+                // matches ordinally, so this is the same case-sensitive presence check for two
+                // lookups instead of a second full pass.
+                var tableEntity = converter.ConvertToTableEntity(entity);
+
+                if (!tableEntity.ContainsKey("PartitionKey") || !tableEntity.ContainsKey("RowKey"))
                 {
                     throw new ArgumentException($"Entity of type {converter.TypeName} is missing required PartitionKey or RowKey properties!");
                 }
 
-                return converter.ConvertToTableEntity(entity);
+                return tableEntity;
             });
 
             var transactionType = ConvertOperationType(operationType);
@@ -371,7 +391,7 @@ public class AzDataTableService
 
         try
         {
-            var transactions = new List<TableTransactionAction>();
+            var transactions = CreateTransactionList(entities);
             var registry = EntityConverterRegistry.Instance;
 
             var tableEntities = entities.Select(entity =>
@@ -383,13 +403,15 @@ public class AzDataTableService
                     throw new ArgumentException($"Unsupported entity type '{entity.GetType().FullName}'. Supported types are: {supportedTypes}");
                 }
 
-                if (!converter.ValidateEntity(entity))
+                // See AddEntitiesToTable: convert once, then check the two required keys on the
+                // dictionary-backed result rather than walking the input a second time.
+                var tableEntity = converter.ConvertToTableEntity(entity);
+
+                if (!tableEntity.ContainsKey("PartitionKey") || !tableEntity.ContainsKey("RowKey"))
                 {
                     throw new ArgumentException($"Entity of type {converter.TypeName} is missing required PartitionKey or RowKey properties!");
                 }
 
-                var tableEntity = converter.ConvertToTableEntity(entity);
-                
                 return tableEntity;
             });
 
@@ -415,7 +437,7 @@ public class AzDataTableService
 
         try
         {
-            var transactions = new List<TableTransactionAction>();
+            var transactions = CreateTransactionList(entities);
             var registry = EntityConverterRegistry.Instance;
 
             var tableEntities = entities.Select(entity =>
@@ -427,13 +449,15 @@ public class AzDataTableService
                     throw new ArgumentException($"Unsupported entity type '{entity.GetType().FullName}'. Supported types are: {supportedTypes}");
                 }
 
-                if (!converter.ValidateEntity(entity))
+                // See AddEntitiesToTable: convert once, then check the two required keys on the
+                // dictionary-backed result rather than walking the input a second time.
+                var tableEntity = converter.ConvertToTableEntity(entity);
+
+                if (!tableEntity.ContainsKey("PartitionKey") || !tableEntity.ContainsKey("RowKey"))
                 {
                     throw new ArgumentException($"Entity of type {converter.TypeName} is missing required PartitionKey or RowKey properties!");
                 }
 
-                var tableEntity = converter.ConvertToTableEntity(entity);
-                
                 return tableEntity;
             });
 
@@ -460,8 +484,22 @@ public class AzDataTableService
 
         try
         {
-            // Declare type as IAsyncEnumerable to be able to overwrite it with LINQ results further down
-            IAsyncEnumerable<TableEntity> entities = TableClient!.QueryAsync<TableEntity>(query, null, properties, CancellationToken);
+            // When the caller wants a bounded number of entities and no sorting is needed, ask the
+            // service for only that many per page. Otherwise the first page returns up to 1000
+            // entities and everything past the requested count is fetched and then discarded.
+            // Sorting has to see every entity, so it opts out of the bound.
+            int? maxPerPage = null;
+            if (top > 0 && (orderBy is null || orderBy.Length == 0))
+            {
+                // Skip is applied client side, so the page still has to cover the skipped entities.
+                var skipped = skip > 0 ? skip.Value : 0;
+                var needed = (long)skipped + top.Value;
+                maxPerPage = needed <= int.MaxValue ? (int)needed : null;
+            }
+
+            // Declare type as IEnumerable to be able to overwrite it with LINQ results further down.
+            // Query rather than QueryAsync: the result is handed back to PowerShell synchronously either way
+            IEnumerable<TableEntity> entities = TableClient!.Query<TableEntity>(query, maxPerPage, properties, CancellationToken);
 
             // If user specified one or more properties to sort list by
             // This may slow the query down a lot with a lot of results
@@ -489,7 +527,7 @@ public class AzDataTableService
 
             // Output entities as hashtables
             // We cannot output the result as TableEntity objects, since we dont (want to) expose the SDK assembly to the user session
-            return entities.ToEnumerable().Select(e =>
+            return entities.Select(e =>
             {
                 PSObject entityObject = new();
                 entityObject.Properties.Add(new PSNoteProperty("ETag", e["odata.etag"]));
@@ -500,6 +538,35 @@ public class AzDataTableService
                 }
                 return entityObject;
             });
+        }
+        catch (Exception ex)
+        {
+            throw new AzDataTableException(new ErrorRecord(ex, "GetEntitiesError", ErrorCategory.InvalidOperation, null));
+        }
+    }
+
+    /// <summary>
+    /// Count the entities in a table matching a query.
+    /// </summary>
+    /// <param name="query">The query to filter entities by.</param>
+    /// <returns>The number of matching entities.</returns>
+    public int CountEntitiesInTable(string query)
+    {
+        ValidateTableClient();
+
+        try
+        {
+            // Only the keys are requested, and the entities are counted without being projected
+            // into PSObjects, since the caller only wants the total.
+            var entities = TableClient!.Query<TableEntity>(query, null, ["PartitionKey", "RowKey"], CancellationToken);
+
+            var count = 0;
+            foreach (var _ in entities)
+            {
+                count++;
+            }
+
+            return count;
         }
         catch (Exception ex)
         {
@@ -542,9 +609,10 @@ public class AzDataTableService
         foreach (var group in transactions.GroupBy(t => t.Entity.PartitionKey))
         {
             // Loop through each group and submit up to 100 at a time
-            for (int i = 0; i < group.Count(); i += 100)
+            var count = group.Count();
+            for (int i = 0; i < count; i += MaxTransactionSize)
             {
-                var response = TableClient!.SubmitTransaction(group.Skip(i).Take(100), CancellationToken);
+                TableClient!.SubmitTransaction(group.Skip(i).Take(MaxTransactionSize), CancellationToken);
             }
         }
     }

--- a/source/AzBobbyTables.Core/Conversion/EntityConverterRegistry.cs
+++ b/source/AzBobbyTables.Core/Conversion/EntityConverterRegistry.cs
@@ -32,7 +32,16 @@ public class EntityConverterRegistry
     /// <returns>A converter that can handle the object, or null if none found.</returns>
     public IEntityConverter GetConverter(object obj)
     {
-        return _converters.FirstOrDefault(c => c.CanConvert(obj));
+        // Indexed loop rather than FirstOrDefault, which boxes an enumerator on every entity.
+        for (int i = 0; i < _converters.Count; i++)
+        {
+            if (_converters[i].CanConvert(obj))
+            {
+                return _converters[i];
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/source/AzBobbyTables.Core/Conversion/HashtableEntityConverter.cs
+++ b/source/AzBobbyTables.Core/Conversion/HashtableEntityConverter.cs
@@ -20,12 +20,29 @@ public class HashtableEntityConverter : IEntityConverter
         if (obj is not Hashtable hashtable)
             return false;
 
-        var hasPartitionKey = hashtable.Keys.Cast<string>()
-            .Any(key => key.Equals("PartitionKey", StringComparison.Ordinal));
-        var hasRowKey = hashtable.Keys.Cast<string>()
-            .Any(key => key.Equals("RowKey", StringComparison.Ordinal));
+        // Single pass over the keys. Cast to string rather than pattern matching so a non-string
+        // key still throws, as Cast<string>() did.
+        var hasPartitionKey = false;
+        var hasRowKey = false;
 
-        return hasPartitionKey && hasRowKey;
+        foreach (string key in hashtable.Keys)
+        {
+            if (!hasPartitionKey && key.Equals("PartitionKey", StringComparison.Ordinal))
+            {
+                hasPartitionKey = true;
+            }
+            else if (!hasRowKey && key.Equals("RowKey", StringComparison.Ordinal))
+            {
+                hasRowKey = true;
+            }
+
+            if (hasPartitionKey && hasRowKey)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public bool ValidateEntityPropertyValuesNotNull(object obj, out IEnumerable<string>? nullProperties)

--- a/source/AzBobbyTables.Core/Conversion/PSObjectEntityConverter.cs
+++ b/source/AzBobbyTables.Core/Conversion/PSObjectEntityConverter.cs
@@ -20,12 +20,29 @@ public class PSObjectEntityConverter : IEntityConverter
         if (obj is not PSObject psobject)
             return false;
 
-        var hasPartitionKey = psobject.Properties
-            .Any(p => p.Name.Equals("PartitionKey", StringComparison.Ordinal));
-        var hasRowKey = psobject.Properties
-            .Any(p => p.Name.Equals("RowKey", StringComparison.Ordinal));
+        // Single pass: enumerating PSObject.Properties goes through the adapter layer, so the
+        // second pass cost as much as the first.
+        var hasPartitionKey = false;
+        var hasRowKey = false;
 
-        return hasPartitionKey && hasRowKey;
+        foreach (var property in psobject.Properties)
+        {
+            if (!hasPartitionKey && property.Name.Equals("PartitionKey", StringComparison.Ordinal))
+            {
+                hasPartitionKey = true;
+            }
+            else if (!hasRowKey && property.Name.Equals("RowKey", StringComparison.Ordinal))
+            {
+                hasRowKey = true;
+            }
+
+            if (hasPartitionKey && hasRowKey)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public TableEntity ConvertToTableEntity(object obj)

--- a/source/AzBobbyTables.Core/Conversion/SortedListEntityConverter.cs
+++ b/source/AzBobbyTables.Core/Conversion/SortedListEntityConverter.cs
@@ -20,12 +20,29 @@ public class SortedListEntityConverter : IEntityConverter
         if (obj is not SortedList sortedList)
             return false;
 
-        var hasPartitionKey = sortedList.Keys.Cast<string>()
-            .Any(key => key.Equals("PartitionKey", StringComparison.Ordinal));
-        var hasRowKey = sortedList.Keys.Cast<string>()
-            .Any(key => key.Equals("RowKey", StringComparison.Ordinal));
+        // Single pass over the keys. Cast to string rather than pattern matching so a non-string
+        // key still throws, as Cast<string>() did.
+        var hasPartitionKey = false;
+        var hasRowKey = false;
 
-        return hasPartitionKey && hasRowKey;
+        foreach (string key in sortedList.Keys)
+        {
+            if (!hasPartitionKey && key.Equals("PartitionKey", StringComparison.Ordinal))
+            {
+                hasPartitionKey = true;
+            }
+            else if (!hasRowKey && key.Equals("RowKey", StringComparison.Ordinal))
+            {
+                hasRowKey = true;
+            }
+
+            if (hasPartitionKey && hasRowKey)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public TableEntity ConvertToTableEntity(object obj)
@@ -35,7 +52,9 @@ public class SortedListEntityConverter : IEntityConverter
 
         var entity = new TableEntity();
         
-        foreach (string key in sortedList.Keys.Cast<string>())
+        // No Cast<string>() needed: the foreach already casts each key, and throws the same way
+        // on a non-string key. Cast only added a second iterator per entity.
+        foreach (string key in sortedList.Keys)
         {
             switch (key)
             {

--- a/source/AzBobbyTables.PS/Cmdlets/AddAzDataTableEntity.cs
+++ b/source/AzBobbyTables.PS/Cmdlets/AddAzDataTableEntity.cs
@@ -2,6 +2,7 @@
 using PipeHow.AzBobbyTables.Validation;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 
@@ -50,6 +51,11 @@ public class AddAzDataTableEntity : AzDataTableOperationCommand
     public SwitchParameter CreateTableIfNotExists { get; set; }
 
     /// <summary>
+    /// Entities gathered from the pipeline, submitted as one batch in EndProcessing.
+    /// </summary>
+    private readonly List<object> entities = new();
+
+    /// <summary>
     /// The process step of the pipeline.
     /// </summary>
     protected override void ProcessRecord()
@@ -65,19 +71,38 @@ public class AddAzDataTableEntity : AzDataTableOperationCommand
             OperationType = "UpsertReplace";
         }
 
-        OperationTypeEnum operationTypeValue;
-        if (Enum.TryParse<OperationTypeEnum>(OperationType, true, out var operationType))
+        if (!Enum.TryParse<OperationTypeEnum>(OperationType, true, out _))
         {
-            operationTypeValue = operationType;
-        }
-        else {
             WriteError(new ErrorRecord(new ArgumentException($"Operation type {OperationType} is not valid!"), "InvalidOperationType", ErrorCategory.InvalidArgument, OperationType));
+            return;
+        }
+
+        // Collect rather than submit. Entity binds one pipeline record at a time, so submitting
+        // here sent a separate transaction per entity instead of batching up to 100.
+        entities.AddRange(Entity);
+    }
+
+    /// <summary>
+    /// Submit everything gathered from the pipeline as a single batched operation.
+    /// The operation type is re-parsed here rather than cached in a field: a field typed from
+    /// AzBobbyTables.Core forces that assembly to load while PowerShell inspects the cmdlet type,
+    /// which happens before OnImport registers the dependency load context.
+    /// </summary>
+    protected override void EndProcessing()
+    {
+        if (tableService is null || entities.Count == 0)
+        {
+            return;
+        }
+
+        if (!Enum.TryParse<OperationTypeEnum>(OperationType, true, out var operationTypeValue))
+        {
             return;
         }
 
         try
         {
-            tableService.AddEntitiesToTable(Entity, operationTypeValue);
+            tableService.AddEntitiesToTable(entities, operationTypeValue);
         }
         catch (AzDataTableException ex)
         {

--- a/source/AzBobbyTables.PS/Cmdlets/GetAzDataTableEntity.cs
+++ b/source/AzBobbyTables.PS/Cmdlets/GetAzDataTableEntity.cs
@@ -80,8 +80,7 @@ public class GetAzDataTableEntity : AzDataTableOperationCommand
         {
             if (Count.IsPresent)
             {
-                var entities = tableService.GetEntitiesFromTable(Filter, new [] { "PartitionKey", "RowKey" }, null, null, null);
-                WriteObject(entities.Count());
+                WriteObject(tableService.CountEntitiesInTable(Filter));
             }
             else
             {

--- a/source/AzBobbyTables.PS/Cmdlets/RemoveAzDataTableEntity.cs
+++ b/source/AzBobbyTables.PS/Cmdlets/RemoveAzDataTableEntity.cs
@@ -1,6 +1,7 @@
 ﻿using PipeHow.AzBobbyTables.Validation;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 
@@ -35,6 +36,11 @@ public class RemoveAzDataTableEntity : AzDataTableOperationCommand
     /// <summary>
     /// The process step of the pipeline.
     /// </summary>
+    /// <summary>
+    /// Entities gathered from the pipeline, submitted as one batch in EndProcessing.
+    /// </summary>
+    private readonly List<object> entities = new();
+
     protected override void ProcessRecord()
     {
         if (tableService is null)
@@ -43,9 +49,24 @@ public class RemoveAzDataTableEntity : AzDataTableOperationCommand
             return;
         }
 
+        // Collect rather than submit. Entity binds one pipeline record at a time, so submitting
+        // here sent a separate transaction per entity instead of batching up to 100.
+        entities.AddRange(Entity);
+    }
+
+    /// <summary>
+    /// Submit everything gathered from the pipeline as a single batched operation.
+    /// </summary>
+    protected override void EndProcessing()
+    {
+        if (tableService is null || entities.Count == 0)
+        {
+            return;
+        }
+
         try
         {
-            tableService.RemoveEntitiesFromTable(Entity, !Force.IsPresent);
+            tableService.RemoveEntitiesFromTable(entities, !Force.IsPresent);
         }
         catch (AzDataTableException ex)
         {

--- a/source/AzBobbyTables.PS/Cmdlets/UpdateAzDataTableEntity.cs
+++ b/source/AzBobbyTables.PS/Cmdlets/UpdateAzDataTableEntity.cs
@@ -2,6 +2,7 @@
 using PipeHow.AzBobbyTables.Validation;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 
@@ -41,6 +42,11 @@ public class UpdateAzDataTableEntity : AzDataTableOperationCommand
     public SwitchParameter Force { get; set; }
 
     /// <summary>
+    /// Entities gathered from the pipeline, submitted as one batch in EndProcessing.
+    /// </summary>
+    private readonly List<object> entities = new();
+
+    /// <summary>
     /// The process step of the pipeline.
     /// </summary>
     protected override void ProcessRecord()
@@ -51,19 +57,38 @@ public class UpdateAzDataTableEntity : AzDataTableOperationCommand
             return;
         }
 
-        OperationTypeEnum operationTypeValue;
-        if (Enum.TryParse<OperationTypeEnum>(OperationType, true, out var operationType))
+        if (!Enum.TryParse<OperationTypeEnum>(OperationType, true, out _))
         {
-            operationTypeValue = operationType;
-        }
-        else {
             WriteError(new ErrorRecord(new ArgumentException($"Operation type {OperationType} is not valid!"), "InvalidOperationType", ErrorCategory.InvalidArgument, OperationType));
+            return;
+        }
+
+        // Collect rather than submit. Entity binds one pipeline record at a time, so submitting
+        // here sent a separate transaction per entity instead of batching up to 100.
+        entities.AddRange(Entity);
+    }
+
+    /// <summary>
+    /// Submit everything gathered from the pipeline as a single batched operation.
+    /// The operation type is re-parsed here rather than cached in a field: a field typed from
+    /// AzBobbyTables.Core forces that assembly to load while PowerShell inspects the cmdlet type,
+    /// which happens before OnImport registers the dependency load context.
+    /// </summary>
+    protected override void EndProcessing()
+    {
+        if (tableService is null || entities.Count == 0)
+        {
+            return;
+        }
+
+        if (!Enum.TryParse<OperationTypeEnum>(OperationType, true, out var operationTypeValue))
+        {
             return;
         }
 
         try
         {
-            tableService.UpdateEntitiesInTable(Entity, operationTypeValue, !Force.IsPresent);
+            tableService.UpdateEntitiesInTable(entities, operationTypeValue, !Force.IsPresent);
         }
         catch (AzDataTableException ex)
         {


### PR DESCRIPTION
## Summary

`Add-`, `Remove-` and `Update-AzDataTableEntity` previously issued one transaction per
pipeline record. Piping N entities meant N round-trips. These now collect entities in
`ProcessRecord` and submit batched transactions in `EndProcessing`.

Alongside that, several allocation hot paths were tightened and the `System.Linq.Async`
dependency removed.

## Changes

**Pipeline batching**
- Add/Remove/Update collect pipeline input and submit batched transactions on completion
- Extracted a `MaxTransactionSize` constant and a `CreateTransactionList` helper

**Query path**
- `QueryAsync` + `ToEnumerable` replaced with synchronous `Query`, dropping `System.Linq.Async`
- `Query` receives a `maxPerPage` hint when `-First` is set without `-Sort`, so the service
  returns a bounded page rather than a full page truncated client-side
- Added `CountEntitiesInTable` so `-Count` no longer projects full PSObjects just to count

**Conversion**
- Entities validated by checking converted `TableEntity` keys rather than a second pass over input
- Single-pass `CanConvert` in the hashtable, PSObject and SortedList converters
- Indexed loop in `EntityConverterRegistry.GetConverter` to avoid boxing the enumerator

## Measured impact

A paginated read workload (2,000 entities, ~27 MB of payload, `-First` paging over one
partition), same script, only the module differs (custom test harness used to test only the memory impact under my certain use-case):

| build | allocated | peak GC heap | time |
|---|---|---|---|
| this PR | 2,488 MB | 37 MB | 11.7s |
| latest | 5,104 MB | 166 MB | 18.5s |

The peak-heap difference is mostly the `maxPerPage` hint: without it `-First` pulls the
partition and truncates client-side, so peak scales with partition size rather than page size.

No public parameter surface changed.