### PR TITLE
bug: Clamp query page size to service limit of 1000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on and uses the types of changes according to [Keep a Change
 
 ## [Unreleased]
 
+### Fixed
+
+- `Get-AzDataTableEntity` no longer fails with `400 InvalidInput` when `-First` is given a value above 1000. The page-size hint introduced in 3.6.1 was passed to the service unclamped, and Azure Table Storage rejects a page size over its limit of 1000 rather than capping it. The hint is now clamped to that limit. Results are unchanged: the hint only sizes each page, so requests for more than 1000 entities are served by paging, as they were before 3.6.1.
+
 ## [3.6.1] - 2026-07-29
 
 ### Changed

--- a/source/AzBobbyTables.Core/AzDataTableService.cs
+++ b/source/AzBobbyTables.Core/AzDataTableService.cs
@@ -113,6 +113,40 @@ public class AzDataTableService
     private const int MaxTransactionSize = 100;
 
     /// <summary>
+    /// The maximum page size Azure Table Storage accepts. A larger value is rejected with
+    /// 400 InvalidInput rather than being capped, so any page size hint must be clamped to it.
+    /// </summary>
+    public const int MaxEntitiesPerPage = 1000;
+
+    /// <summary>
+    /// Calculates the page size to request for a query, or null to accept the service default.
+    /// </summary>
+    /// <remarks>
+    /// Only a hint: it sizes each page, it does not limit the total. The caller still applies
+    /// Take, and the SDK pages through transparently when more than one page is needed.
+    /// Returns null when sorting, because ordering has to see every entity.
+    /// The result is clamped to <see cref="MaxEntitiesPerPage"/> because the service rejects a
+    /// larger page size outright with 400 InvalidInput instead of capping it. Note that Azurite
+    /// does not enforce that limit, so only a direct assertion on this value catches a regression.
+    /// </remarks>
+    /// <param name="top">Maximum number of entities the caller asked for.</param>
+    /// <param name="skip">Number of entities to skip; applied client side, so the page must cover them.</param>
+    /// <param name="orderBy">Properties to sort by, if any.</param>
+    /// <returns>The page size to request, or null for the service default.</returns>
+    public static int? CalculatePageSize(int? top, int? skip, string[] orderBy)
+    {
+        if (!(top > 0) || (orderBy is not null && orderBy.Length > 0))
+        {
+            return null;
+        }
+
+        var skipped = skip > 0 ? skip.Value : 0;
+        var needed = (long)skipped + top.Value;
+
+        return (int)Math.Min(needed, MaxEntitiesPerPage);
+    }
+
+    /// <summary>
     /// Creates the transaction list, presized when the source count is known to avoid regrowing it.
     /// </summary>
     private static List<TableTransactionAction> CreateTransactionList(IEnumerable<object> entities) =>
@@ -487,15 +521,7 @@ public class AzDataTableService
             // When the caller wants a bounded number of entities and no sorting is needed, ask the
             // service for only that many per page. Otherwise the first page returns up to 1000
             // entities and everything past the requested count is fetched and then discarded.
-            // Sorting has to see every entity, so it opts out of the bound.
-            int? maxPerPage = null;
-            if (top > 0 && (orderBy is null || orderBy.Length == 0))
-            {
-                // Skip is applied client side, so the page still has to cover the skipped entities.
-                var skipped = skip > 0 ? skip.Value : 0;
-                var needed = (long)skipped + top.Value;
-                maxPerPage = needed <= int.MaxValue ? (int)needed : null;
-            }
+            var maxPerPage = CalculatePageSize(top, skip, orderBy);
 
             // Declare type as IEnumerable to be able to overwrite it with LINQ results further down.
             // Query rather than QueryAsync: the result is handed back to PowerShell synchronously either way

--- a/tests/AzuriteIntegration.Tests.ps1
+++ b/tests/AzuriteIntegration.Tests.ps1
@@ -409,6 +409,53 @@ Describe 'Azurite Integration Tests' -Tag 'Integration' {
         }
     }
 
+    Context 'Result limits across the page boundary' {
+        BeforeAll {
+            # A page holds at most 1000 entities, so this spans more than one page.
+            $Script:PagingTable = 'AzBobbyTablesPaging'
+            $Script:PagingContext = New-AzDataTableContext -TableName $Script:PagingTable -ConnectionString 'UseDevelopmentStorage=true'
+            New-AzDataTable -Context $Script:PagingContext -ErrorAction SilentlyContinue | Out-Null
+
+            $Entities = 1..1500 | ForEach-Object {
+                @{ PartitionKey = 'Paging'; RowKey = ('{0:D5}' -f $_); Value = "value-$_" }
+            }
+            for ($i = 0; $i -lt $Entities.Count; $i += 100) {
+                $End = [Math]::Min($i + 99, $Entities.Count - 1)
+                Add-AzDataTableEntity -Context $Script:PagingContext -Entity $Entities[$i..$End] -Force
+            }
+        }
+
+        It 'returns <Expected> entities for -First <First>' -TestCases @(
+            @{ First = 1; Expected = 1 }
+            @{ First = 999; Expected = 999 }
+            @{ First = 1000; Expected = 1000 }
+            @{ First = 1001; Expected = 1001 }
+            @{ First = 1500; Expected = 1500 }
+            @{ First = 10000; Expected = 1500 }   # more than exists, and more than one page
+        ) {
+            @(Get-AzDataTableEntity -Context $Script:PagingContext -First $First).Count | Should -BeExactly $Expected
+        }
+
+        It 'applies -Skip across a page boundary' {
+            @(Get-AzDataTableEntity -Context $Script:PagingContext -Skip 1400 -First 10000).Count | Should -BeExactly 100
+        }
+
+        It 'returns every entity when no limit is given' {
+            @(Get-AzDataTableEntity -Context $Script:PagingContext).Count | Should -BeExactly 1500
+        }
+
+        It 'sorts across the whole set, not just the first page' {
+            # Sorting opts out of the page bound, so the last RowKey must be reachable.
+            $Sorted = @(Get-AzDataTableEntity -Context $Script:PagingContext -Sort 'RowKey' -First 1)
+            $Sorted.Count | Should -BeExactly 1
+            $Sorted[0].RowKey | Should -BeExactly '00001'
+        }
+
+        AfterAll {
+            Remove-AzDataTable -Context $Script:PagingContext -ErrorAction SilentlyContinue
+        }
+    }
+
     Context 'Type Coverage Validation' {
         It 'should have integration tests for all supported entity types' {
             # Get the list of supported entity types from the module

--- a/tests/PageSize.Tests.ps1
+++ b/tests/PageSize.Tests.ps1
@@ -1,0 +1,93 @@
+BeforeAll {
+    # AzDataTableService.CalculatePageSize decides the page size sent to the service as $top.
+    #
+    # Asserted directly rather than through a query, on purpose: Azurite does not enforce the 1000
+    # page-size limit, so a behavioural test passes against the emulator whether or not the value
+    # is clamped. Only real Azure rejects an oversized page size, with 400 InvalidInput rather than
+    # capping it. A -First 10000 call shipped and failed in production through exactly that gap,
+    # so the value itself is what needs asserting.
+    #
+    # Reached by reflection because AzBobbyTables.Core is loaded into the module's private
+    # AssemblyLoadContext and its types are deliberately not resolvable from the session.
+    Get-AzDataTableSupportedEntityType | Out-Null   # forces Core to load
+
+    $CoreAssembly = foreach ($Context in [System.Runtime.Loader.AssemblyLoadContext]::All) {
+        foreach ($Assembly in $Context.Assemblies) {
+            if ($Assembly.GetName().Name -eq 'AzBobbyTables.Core') { $Assembly }
+        }
+    }
+
+    $Script:ServiceType = @($CoreAssembly)[0].GetType('PipeHow.AzBobbyTables.Core.AzDataTableService')
+    $Script:PageSizeMethod = $Script:ServiceType.GetMethod('CalculatePageSize')
+    $Script:Limit = $Script:ServiceType.GetField('MaxEntitiesPerPage').GetValue($null)
+
+    function Get-PageSize {
+        param($Top, $Skip, $Sort)
+        $Script:PageSizeMethod.Invoke($null, @($Top, $Skip, $Sort))
+    }
+}
+
+Describe 'Query page size' {
+    It 'resolves the service limit' {
+        $Script:Limit | Should -BeExactly 1000
+    }
+
+    Context 'clamping to the service limit' {
+
+        It 'clamps <Description>' -TestCases @(
+            @{ Description = 'a request just over the limit'; Top = 1001; Skip = $null }
+            @{ Description = 'the size that broke Push-GetPendingWebhooks'; Top = 10000; Skip = $null }
+            @{ Description = 'a very large request'; Top = [int]::MaxValue; Skip = $null }
+            @{ Description = 'a skip and top that only exceed the limit combined'; Top = 600; Skip = 600 }
+            @{ Description = 'a skip and top that would overflow Int32 if added'; Top = [int]::MaxValue; Skip = [int]::MaxValue }
+        ) {
+            Get-PageSize -Top $Top -Skip $Skip -Sort $null | Should -BeExactly $Script:Limit
+        }
+
+        It 'never exceeds the limit for any requested size' {
+            foreach ($Top in 1, 999, 1000, 1001, 5000, 100000, [int]::MaxValue) {
+                $Size = Get-PageSize -Top $Top -Skip $null -Sort $null
+                $Size | Should -BeLessOrEqual $Script:Limit
+                $Size | Should -BeGreaterThan 0
+            }
+        }
+    }
+
+    Context 'requests at or under the limit pass through' {
+
+        It 'asks for exactly <Top>' -TestCases @(
+            @{ Top = 1 }
+            @{ Top = 5 }
+            @{ Top = 999 }
+            @{ Top = 1000 }
+        ) {
+            Get-PageSize -Top $Top -Skip $null -Sort $null | Should -BeExactly $Top
+        }
+
+        It 'covers the skipped entities as well as the requested ones' {
+            # Skip is applied client side, so the page has to include what will be discarded.
+            Get-PageSize -Top 10 -Skip 90 -Sort $null | Should -BeExactly 100
+        }
+    }
+
+    Context 'cases that must not bound the query' {
+
+        It 'returns null when <Description>' -TestCases @(
+            @{ Description = 'no limit was requested'; Top = $null; Skip = $null }
+            @{ Description = 'Top is zero'; Top = 0; Skip = $null }
+            @{ Description = 'Top is negative'; Top = -1; Skip = $null }
+            @{ Description = 'only Skip was given'; Top = $null; Skip = 50 }
+        ) {
+            Get-PageSize -Top $Top -Skip $Skip -Sort $null | Should -BeNullOrEmpty
+        }
+
+        It 'returns null when sorting, because ordering has to see every entity' {
+            Get-PageSize -Top 5 -Skip $null -Sort ([string[]]@('Name')) | Should -BeNullOrEmpty
+            Get-PageSize -Top 5 -Skip 10 -Sort ([string[]]@('Name', 'Id')) | Should -BeNullOrEmpty
+        }
+
+        It 'still bounds the query when Sort is an empty array' {
+            Get-PageSize -Top 5 -Skip $null -Sort ([string[]]@()) | Should -BeExactly 5
+        }
+    }
+}

--- a/tests/PageSize.Tests.ps1
+++ b/tests/PageSize.Tests.ps1
@@ -36,7 +36,7 @@ Describe 'Query page size' {
 
         It 'clamps <Description>' -TestCases @(
             @{ Description = 'a request just over the limit'; Top = 1001; Skip = $null }
-            @{ Description = 'the size that broke Push-GetPendingWebhooks'; Top = 10000; Skip = $null }
+            @{ Description = 'a request much above the limit'; Top = 10000; Skip = $null }
             @{ Description = 'a very large request'; Top = [int]::MaxValue; Skip = $null }
             @{ Description = 'a skip and top that only exceed the limit combined'; Top = 600; Skip = 600 }
             @{ Description = 'a skip and top that would overflow Int32 if added'; Top = [int]::MaxValue; Skip = [int]::MaxValue }


### PR DESCRIPTION
This pull request introduces a new logic for calculating and enforcing the page size for Azure Table Storage queries, ensuring compliance with the service's hard limit and preventing errors in production. It also adds comprehensive unit and integration tests to verify correct paging and boundary behaviors.

**Page size calculation and enforcement:**

* Added the `CalculatePageSize` method and the `MaxEntitiesPerPage` constant (1000) to `AzDataTableService`, ensuring that any page size hint passed to Azure Table Storage is clamped to the service's maximum allowed value. This prevents 400 InvalidInput errors when a client requests more entities per page than allowed.
* Refactored `GetEntitiesFromTable` to use the new `CalculatePageSize` logic, centralizing and simplifying page size determination.

**Testing and validation:**

* Added a new unit test suite (`PageSize.Tests.ps1`) that directly asserts the output of `CalculatePageSize` for various edge cases, including clamping, overflow, and sorting scenarios. This ensures the logic is robust and not dependent on emulator behavior.
* Introduced new integration tests in `AzuriteIntegration.Tests.ps1` that verify correct entity counts and paging behavior across page boundaries, including skip and sort scenarios, using the Azurite emulator.Azure Table Storage rejects page sizes above 1000 with 400 InvalidInput instead of capping them. Extract CalculatePageSize as a public static method that clamps the page size hint to MaxEntitiesPerPage (1000), covering the skip+top combined case and overflow. Add unit tests asserting the clamping directly (Azurite does not enforce the limit so behavioural tests alone miss this), and add integration tests for result limits across the page boundary.

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or failed tests.
- [x] Markdown help added/updated.
- [x] Unit tests added/updated.
