### PR TITLE
fix: Skip incomplete large entities in queries and return non-terminating error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on and uses the types of changes according to [Keep a Change
 
 ## [Unreleased]
 
+### Changed
+
+- `Get-AzDataTableLargeEntity` no longer fails an entire query when one entity cannot be reassembled. It skips that entity and reports it as a non-terminating error, with `IncompleteEntity` as the FullyQualifiedErrorId and `PartitionKey/RowKey` as the target, so the entities returned alongside it still come back. Previously the `IncompleteEntityException` was raised from the middle of the result set, so a single part row whose master row was missing — left behind by a delete that did not remove its parts, or by editing the table directly — discarded every other entity matched by the same filter. Use `-ErrorAction Stop` for the previous behaviour.
+
 ## [3.7.0] - 2026-08-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on and uses the types of changes according to [Keep a Change
 
 ### Changed
 
-- `Get-AzDataTableLargeEntity` no longer fails an entire query when one entity cannot be reassembled. It skips that entity and reports it as a non-terminating error, with `IncompleteEntity` as the FullyQualifiedErrorId and `PartitionKey/RowKey` as the target, so the entities returned alongside it still come back. Previously the `IncompleteEntityException` was raised from the middle of the result set, so a single part row whose master row was missing — left behind by a delete that did not remove its parts, or by editing the table directly — discarded every other entity matched by the same filter. Use `-ErrorAction Stop` for the previous behaviour.
+- `Get-AzDataTableLargeEntity` no longer fails an entire query when one entity cannot be reassembled. It skips that entity and reports it as a non-terminating error. Use `-ErrorAction Stop` for the previous behavior.
 
 ## [3.7.0] - 2026-08-10
 

--- a/source/AzBobbyTables.Core/AzDataTableService.cs
+++ b/source/AzBobbyTables.Core/AzDataTableService.cs
@@ -220,6 +220,12 @@ public class AzDataTableService
     internal void LogError(string message, string? code = null, string? context = null) =>
         Log(PSLogLevel.Error, message, code, context);
 
+    /// <summary>
+    /// FullyQualifiedErrorId for an entity skipped because its rows could not be reassembled.
+    /// Stable so callers can filter on it; Context carries "PartitionKey/RowKey".
+    /// </summary>
+    public const string IncompleteEntityErrorCode = "IncompleteEntity";
+
 
     private TableTransactionActionType ConvertOperationType(OperationTypeEnum operationType) =>
         Enum.TryParse(operationType.ToString(), out TableTransactionActionType transactionType)
@@ -848,7 +854,16 @@ public class AzDataTableService
             // caller's filter has no reason to match the rows an entity was split over.
             var rows = RecoverMissingPartRows(entities.ToList(), properties);
 
-            return EntitySplitter.Reassemble(rows, onWarning)
+            // An entity that cannot be reassembled is reported and left out rather than failing the
+            // query: missing rows are a property of that entity alone, and the others returned by
+            // the same filter are unaffected by it.
+            return EntitySplitter.Reassemble(
+                    rows,
+                    onWarning,
+                    incomplete => LogError(
+                        incomplete.Message,
+                        IncompleteEntityErrorCode,
+                        $"{incomplete.EntityPartitionKey}/{incomplete.EntityRowKey}"))
                 .Select(ProjectToPSObject)
                 .ToList();
         }

--- a/source/AzBobbyTables.Core/EntitySplitter.cs
+++ b/source/AzBobbyTables.Core/EntitySplitter.cs
@@ -339,7 +339,12 @@ public static class EntitySplitter
     /// </summary>
     /// <param name="entities">The physical rows, e.g. the result of a table query.</param>
     /// <param name="onWarning">Called with a message when a malformed manifest is skipped.</param>
-    public static IEnumerable<TableEntity> Reassemble(IEnumerable<TableEntity> entities, Action<string>? onWarning = null)
+    /// <param name="onIncomplete">
+    /// Called for each entity whose rows or split-property chunks are missing. That entity
+    /// is left out of the results and the rest are still returned, so one entity with rows
+    /// missing does not hide the entities returned alongside it.
+    /// </param>
+    public static IEnumerable<TableEntity> Reassemble(IEnumerable<TableEntity> entities, Action<string>? onWarning = null, Action<IncompleteEntityException>? onIncomplete = null)
     {
         var (order, groups) = GroupRows(entities);
 
@@ -356,10 +361,11 @@ public static class EntitySplitter
             {
                 if (DescribeIncompleteness(group) is { } reason)
                 {
-                    throw new IncompleteEntityException(
+                    onIncomplete?.Invoke(new IncompleteEntityException(
                         key.PartitionKey,
                         key.EntityId,
-                        $"Cannot reassemble entity with PartitionKey='{key.PartitionKey}' and RowKey='{key.EntityId}': {reason} The query must return every row the entity was split over.");
+                        $"Skipped entity with PartitionKey='{key.PartitionKey}' and RowKey='{key.EntityId}': {reason}"));
+                    continue;
                 }
 
                 result = MergeParts(group.Parts, key.PartitionKey, key.EntityId);
@@ -369,7 +375,16 @@ public static class EntitySplitter
                 continue;
             }
 
-            JoinSplitProperties(result, onWarning);
+            try
+            {
+                JoinSplitProperties(result, onWarning);
+            }
+            catch (IncompleteEntityException ex)
+            {
+                onIncomplete?.Invoke(ex);
+                continue;
+            }
+
             yield return result;
         }
     }

--- a/tests/LargeEntityIntegration.Tests.ps1
+++ b/tests/LargeEntityIntegration.Tests.ps1
@@ -511,24 +511,48 @@ Describe 'Large Entity Integration Tests' -Tag 'Integration' {
             $root.SplitOverProps | Should -Not -BeNullOrEmpty
         }
 
-        It 'fails loudly when a row is genuinely gone rather than returning a fragment' {
-            # A deleted row cannot be recovered, and what survives would be a truncated
-            # value indistinguishable from real data.
+        It 'skips an unreconstructable entity, reports it, and still returns the rest' {
+            # A part row whose master row is gone cannot be recovered, and must not take the intact
+            # entities in the same partition with it.
             $orphanTable = "AzBobbyTablesLEOrphan$([guid]::NewGuid().ToString('N').Substring(0, 8))"
             $orphanContext = New-AzDataTableContext -TableName $orphanTable -ConnectionString $ConnectionString
             $null = New-AzDataTable -Context $orphanContext
             try {
                 Add-AzDataTableLargeEntity -Context $orphanContext -Entity @{
-                    PartitionKey = 'o'; RowKey = 'split'; Data = (New-PatternString -Length 1500000 -Seed 'ORPHAN')
+                    PartitionKey = 'o'; RowKey = 'broken'; Data = (New-PatternString -Length 1500000 -Seed 'ORPHAN')
                 } -Force
+                Add-AzDataTableLargeEntity -Context $orphanContext -Entity @{ PartitionKey = 'o'; RowKey = 'intact-a'; V = 1 } -Force
+                Add-AzDataTableLargeEntity -Context $orphanContext -Entity @{ PartitionKey = 'o'; RowKey = 'intact-b'; V = 2 } -Force
 
-                $rows = @(Get-AzDataTableEntity -Context $orphanContext -Filter "PartitionKey eq 'o'" -Property PartitionKey, RowKey)
-                $rows.Count | Should -BeGreaterThan 1
-                $tail = $rows | Sort-Object RowKey | Select-Object -Last 1
-                Remove-AzDataTableEntity -Context $orphanContext -Entity @{ PartitionKey = 'o'; RowKey = $tail.RowKey }
+                # Orphan the parts by deleting only the master row.
+                Remove-AzDataTableEntity -Context $orphanContext -Entity @{ PartitionKey = 'o'; RowKey = 'broken' }
 
-                { Get-AzDataTableLargeEntity -Context $orphanContext -Filter "PartitionKey eq 'o'" -ErrorAction Stop } |
-                Should -Throw -Because 'a truncated entity must not be presented as a whole one'
+                $result = @(Get-AzDataTableLargeEntity -Context $orphanContext -Filter "PartitionKey eq 'o'" -ErrorAction SilentlyContinue -ErrorVariable skipped)
+
+                @($result.RowKey | Sort-Object) | Should -Be @('intact-a', 'intact-b')
+                @($skipped).Count | Should -Be 1
+                $skipped[0].FullyQualifiedErrorId | Should -BeLike 'IncompleteEntity*'
+                # Context carries PartitionKey/RowKey so a caller can name the row to remove.
+                $skipped[0].TargetObject | Should -Be 'o/broken'
+            } finally {
+                Remove-AzDataTable -Context $orphanContext
+            }
+        }
+
+        It 'does not fail the query when an entity is skipped' {
+            $orphanTable = "AzBobbyTablesLENonTerm$([guid]::NewGuid().ToString('N').Substring(0, 8))"
+            $orphanContext = New-AzDataTableContext -TableName $orphanTable -ConnectionString $ConnectionString
+            $null = New-AzDataTable -Context $orphanContext
+            try {
+                Add-AzDataTableLargeEntity -Context $orphanContext -Entity @{
+                    PartitionKey = 'n'; RowKey = 'broken'; Data = (New-PatternString -Length 1500000 -Seed 'NONTERM')
+                } -Force
+                Remove-AzDataTableEntity -Context $orphanContext -Entity @{ PartitionKey = 'n'; RowKey = 'broken' }
+
+                # The report is non-terminating, so the pipeline continues unless the caller opts
+                # into -ErrorAction Stop.
+                { Get-AzDataTableLargeEntity -Context $orphanContext -Filter "PartitionKey eq 'n'" -ErrorAction SilentlyContinue } |
+                Should -Not -Throw
             } finally {
                 Remove-AzDataTable -Context $orphanContext
             }


### PR DESCRIPTION
Change large-entity reassembly to skip unreconstructable entities instead of aborting the whole query. `Reassemble` now reports `IncompleteEntityException` through a callback, and `AzDataTableService` logs it as a non-terminating error with stable FullyQualifiedErrorId `IncompleteEntity` and `PartitionKey/RowKey` in the target context. Integration tests were updated to verify intact entities still return, the skip is reported once, and queries only become terminating when callers opt into `-ErrorAction Stop`; changelog updated accordingly.

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or failed tests.
- [x] Markdown help added/updated.
- [x] Unit tests added/updated.
