### PR TITLE
feat: Add Update-AzDataTableLargeEntity and fix batched updates creating missing entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on and uses the types of changes according to [Keep a Change
 
 ### Added
 
-- Added `Update-AzDataTableLargeEntity` for updating entities that exceed the Azure Table Storage size limits. Unlike the upsert operation types of `Add-AzDataTableLargeEntity`, entities that do not exist cause an error instead of being created. `UpdateReplace` rewrites the logical entity and removes part rows the new version no longer uses; `UpdateMerge` merges a plain single-row entity in place, and reads, merges and rewrites entities that were split for size, since merging onto physical rows directly would corrupt reassembly.
+- Added `Update-AzDataTableLargeEntity` for updating entities that exceed the Azure Table Storage size limits, allowing for updates of entities added by `Add-AzDataTableLargeEntity`.
 
 ### Fixed
 
-- `Update-AzDataTableEntity` no longer creates entities that do not exist when called with `-Force` or with entities that carry no ETag. Batched update actions were submitted without an `If-Match` header in those cases, which the table service treats as an insert-or-merge. Update actions now always carry `If-Match` (`*` when no ETag applies), matching the non-batched path and the documented behavior.
+- `Update-AzDataTableEntity` no longer creates entities that do not exist when called with `-Force` or with entities that carry no ETag.
 
 ## [3.7.1] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on and uses the types of changes according to [Keep a Change
 
 ## [Unreleased]
 
+### Added
+
+- Added `Update-AzDataTableLargeEntity` for updating entities that exceed the Azure Table Storage size limits. Unlike the upsert operation types of `Add-AzDataTableLargeEntity`, entities that do not exist cause an error instead of being created. `UpdateReplace` rewrites the logical entity and removes part rows the new version no longer uses; `UpdateMerge` merges a plain single-row entity in place, and reads, merges and rewrites entities that were split for size, since merging onto physical rows directly would corrupt reassembly.
+
+### Fixed
+
+- `Update-AzDataTableEntity` no longer creates entities that do not exist when called with `-Force` or with entities that carry no ETag. Batched update actions were submitted without an `If-Match` header in those cases, which the table service treats as an insert-or-merge. Update actions now always carry `If-Match` (`*` when no ETag applies), matching the non-batched path and the documented behavior.
+
 ## [3.7.1] - 2026-08-12
 
 ### Changed

--- a/docs/help/Update-AzDataTableLargeEntity.md
+++ b/docs/help/Update-AzDataTableLargeEntity.md
@@ -1,0 +1,153 @@
+---
+external help file: AzBobbyTables.PS.dll-Help.xml
+Module Name: AzBobbyTables
+online version:
+schema: 2.0.0
+---
+
+# Update-AzDataTableLargeEntity
+
+## SYNOPSIS
+
+Update one or more entities that already exist in an Azure Table, transparently handling entities that were split across multiple properties or rows by `Add-AzDataTableLargeEntity`.
+
+## SYNTAX
+
+```
+Update-AzDataTableLargeEntity -Context <AzDataTableContext> -Entity <Object[]> [-OperationType <String>]
+ [-Force] [-MaxRetries <Int32>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Update one or more entities that already exist in an Azure Table, based on PartitionKey and RowKey. Entities that do not exist cause an error and are never created, unlike the upsert operation types of `Add-AzDataTableLargeEntity`.
+
+`UpdateReplace` replaces the whole logical entity: the entity's own row is updated (and fails if missing), any additional part rows the new version needs are upserted, and part rows the new version no longer uses are removed.
+
+`UpdateMerge` merges the given properties into the logical entity. A plain single-row entity is merged in place. An entity that was split for size, or given properties that are themselves oversized, are read, merged in memory and rewritten, since merging onto the physical rows directly would corrupt the split-entity format.
+
+ETag validation, when not skipped with the `Force` parameter, applies to the entity's own row. The read-merge-rewrite path is not atomic.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> $Context = New-AzDataTableContext -TableName $TableName -ConnectionString $ConnectionString
+PS C:\> Update-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'tenant1'; RowKey = 'record1'; Processed = $true }
+```
+
+Merge a property onto an existing entity. If the entity does not exist, the update fails instead of creating it.
+
+### Example 2
+
+```powershell
+PS C:\> $Entity = Get-AzDataTableLargeEntity -Context $Context -Filter "RowKey eq 'record1'"
+PS C:\> $Entity.Data = $NewLargeValue
+PS C:\> Update-AzDataTableLargeEntity -Context $Context -Entity $Entity -OperationType UpdateReplace
+```
+
+Replace an existing entity with a new version, splitting it over properties and rows as needed and removing part rows the new version no longer uses. The ETag from the read is validated, so a concurrent change fails the update.
+
+## PARAMETERS
+
+### -Context
+
+A context object created by New-AzDataTableContext, with authentication information for the table to operate on.
+
+```yaml
+Type: AzDataTableContext
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Entity
+
+The entities to update in the table.
+
+```yaml
+Type: Object[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Force
+
+Skips ETag validation and updates entity even if it has changed.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxRetries
+The number of times to retry the operation when the request is throttled by the service with an HTTP 429 response. Between attempts the module waits for the duration indicated by the service's Retry-After response. Defaults to 0, which disables retries.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OperationType
+
+The type of operation to perform on the entities, either UpdateMerge or UpdateReplace. Defaults to UpdateMerge.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: UpdateMerge, UpdateReplace
+
+Required: False
+Position: Named
+Default value: UpdateMerge
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Collections.Hashtable[] or System.Management.Automation.PSObject[] or System.Collections.SortedList[]
+
+This cmdlet takes either an array of hashtables, psobjects, or sorted lists as input to the Entity parameter, which can also be provided through the pipeline.
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+## RELATED LINKS
+
+[Add-AzDataTableLargeEntity](Add-AzDataTableLargeEntity.md)
+[Get-AzDataTableLargeEntity](Get-AzDataTableLargeEntity.md)
+[Remove-AzDataTableLargeEntity](Remove-AzDataTableLargeEntity.md)

--- a/source/AzBobbyTables.Core/AzDataTableService.cs
+++ b/source/AzBobbyTables.Core/AzDataTableService.cs
@@ -545,7 +545,15 @@ public class AzDataTableService
             });
 
             var transactionType = ConvertOperationType(operationType);
-            transactions.AddRange(tableEntities.Select(e => new TableTransactionAction(transactionType, e, validateEtag ? e.ETag : default)));
+
+            // Update actions must always carry If-Match; with a default ETag the
+            // service treats a batched merge or replace as an upsert and silently
+            // creates missing rows. ETag.All matches the non-batched path.
+            transactions.AddRange(tableEntities.Select(e =>
+            {
+                var etag = validateEtag && e.ETag != default ? e.ETag : ETag.All;
+                return new TableTransactionAction(transactionType, e, etag);
+            }));
 
             SubmitTransaction(transactions);
         }
@@ -994,6 +1002,222 @@ public class AzDataTableService
         {
             throw new AzDataTableException(new ErrorRecord(ex, "RemoveLargeEntitiesError", ErrorCategory.InvalidOperation, null));
         }
+    }
+
+    /// <summary>
+    /// Update one or more entities that already exist in a table, transparently
+    /// handling entities that were split across multiple properties or rows by the
+    /// large-entity write path. See <see cref="EntitySplitter"/> for the storage
+    /// format. Unlike <see cref="AddLargeEntitiesToTable"/> with an upsert operation
+    /// type, entities that do not exist cause an error and are never created.
+    ///
+    /// UpdateReplace replaces the whole logical entity: the root row is updated (and
+    /// fails if missing), part rows the new version needs are upserted, and part rows
+    /// it no longer uses are removed.
+    ///
+    /// UpdateMerge merges the given properties into the logical entity. A plain
+    /// single-row entity is merged in place; an entity that was split, or incoming
+    /// properties that are themselves oversized, are read, merged in memory and
+    /// rewritten, since merging onto physical rows directly would corrupt reassembly.
+    ///
+    /// ETag validation, when requested, applies to the entity's root row. The
+    /// read-merge-rewrite path is not atomic.
+    /// </summary>
+    /// <param name="entities">The entities to update (can be any supported type).</param>
+    /// <param name="operationType">The type of operation to perform, UpdateMerge or UpdateReplace.</param>
+    /// <param name="validateEtag">Whether or not to validate that the ETag is the same and the item has not changed.</param>
+    public void UpdateLargeEntitiesInTable(IEnumerable<object> entities, OperationTypeEnum operationType, bool validateEtag = true)
+    {
+        ValidateTableClient();
+
+        try
+        {
+            if (operationType is not (OperationTypeEnum.UpdateMerge or OperationTypeEnum.UpdateReplace))
+            {
+                throw new ArgumentException($"Operation type {operationType} is not valid for updates, use UpdateMerge or UpdateReplace!");
+            }
+
+            // Deduplicate by entity identity, last one wins, same as the add path.
+            var order = new List<(string PartitionKey, string RowKey)>();
+            var latest = new Dictionary<(string PartitionKey, string RowKey), TableEntity>();
+            foreach (var entity in entities)
+            {
+                var tableEntity = ConvertToValidatedTableEntity(entity);
+                var key = (tableEntity.PartitionKey, tableEntity.RowKey);
+                if (!latest.ContainsKey(key))
+                {
+                    order.Add(key);
+                }
+                latest[key] = tableEntity;
+            }
+
+            // Updating requires existence, and the merge path needs the split markers
+            // to decide whether merging onto the root row directly is safe.
+            var storedRoots = FetchRootRows(order);
+
+            var missing = order.Where(key => !storedRoots.ContainsKey(key)).ToList();
+            if (missing.Count > 0)
+            {
+                var described = string.Join(", ", missing.Select(k => $"PartitionKey='{k.PartitionKey}' RowKey='{k.RowKey}'"));
+                throw new InvalidOperationException($"Cannot update one or more entities because they do not exist: {described}");
+            }
+
+            var actions = new List<TableTransactionAction>(order.Count);
+            var splitEntities = new List<(string PartitionKey, string RowKey, HashSet<string> LiveRowKeys)>();
+
+            foreach (var key in order)
+            {
+                var incoming = latest[key];
+                var storedRoot = storedRoots[key];
+                // Update actions must always carry If-Match; with a default ETag the
+                // service treats a batched merge or replace as an upsert.
+                var etag = validateEtag && incoming.ETag != default ? incoming.ETag : ETag.All;
+                var storedIsSplit = HasSplitMarkers(storedRoot);
+
+                if (operationType == OperationTypeEnum.UpdateMerge)
+                {
+                    if (!storedIsSplit)
+                    {
+                        var incomingSplit = EntitySplitter.Split(incoming);
+                        if (!incomingSplit.Engaged)
+                        {
+                            // Plain stored row, plain incoming properties: one merge.
+                            actions.Add(new TableTransactionAction(TableTransactionActionType.UpdateMerge, incomingSplit.Rows[0], etag));
+                            continue;
+                        }
+                        // Oversized incoming properties fall through to the
+                        // read-merge-rewrite path so the stored properties survive.
+                    }
+
+                    var stored = ReadLogicalEntity(key.PartitionKey, key.RowKey);
+                    var merged = new TableEntity(key.PartitionKey, key.RowKey);
+                    foreach (var property in stored)
+                    {
+                        if (property.Key is "PartitionKey" or "RowKey" or "Timestamp" or "odata.etag" or "ETag")
+                        {
+                            continue;
+                        }
+                        merged[property.Key] = property.Value;
+                    }
+                    foreach (var property in incoming)
+                    {
+                        if (property.Key is "PartitionKey" or "RowKey" or "Timestamp" or "odata.etag" or "ETag")
+                        {
+                            continue;
+                        }
+                        merged[property.Key] = property.Value;
+                    }
+                    incoming = merged;
+                }
+
+                var result = EntitySplitter.Split(incoming);
+
+                // Update rather than upsert the root row, so an entity deleted since
+                // the existence check fails instead of being partially recreated.
+                actions.Add(new TableTransactionAction(TableTransactionActionType.UpdateReplace, result.Rows[0], etag));
+                foreach (var row in result.Rows.Skip(1))
+                {
+                    actions.Add(new TableTransactionAction(TableTransactionActionType.UpsertReplace, row));
+                }
+
+                if (result.Engaged || storedIsSplit)
+                {
+                    splitEntities.Add((key.PartitionKey, key.RowKey, new HashSet<string>(result.Rows.Select(r => r.RowKey), StringComparer.Ordinal)));
+                }
+            }
+
+            SubmitTransactionSized(actions);
+
+            // Remove leftover part rows from earlier writes that used more rows than
+            // this one, so stale data cannot leak into reassembly.
+            foreach (var (partitionKey, rowKey, liveRowKeys) in splitEntities)
+            {
+                RemoveStalePartRows(partitionKey, rowKey, liveRowKeys);
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new AzDataTableException(new ErrorRecord(ex, "UpdateLargeEntitiesError", ErrorCategory.InvalidOperation, null));
+        }
+    }
+
+    /// <summary>
+    /// Properties needed to classify a stored root row for the update path: the split
+    /// markers, and the keys.
+    /// </summary>
+    private static readonly string[] RootMarkerProperties =
+    {
+        "PartitionKey",
+        "RowKey",
+        EntitySplitter.SplitOverPropsKey,
+        EntitySplitter.PartCountKey,
+        EntitySplitter.OriginalEntityIdKey,
+    };
+
+    /// <summary>
+    /// Fetch the root rows for the given logical entity keys, selecting only the keys
+    /// and split markers. RowKeys are matched in chunked OR filters to keep the number
+    /// of queries low. Keys whose root row does not exist are absent from the result.
+    /// </summary>
+    private Dictionary<(string PartitionKey, string RowKey), TableEntity> FetchRootRows(List<(string PartitionKey, string RowKey)> keys)
+    {
+        var found = new Dictionary<(string PartitionKey, string RowKey), TableEntity>();
+
+        foreach (var partitionGroup in keys.GroupBy(k => k.PartitionKey, StringComparer.Ordinal))
+        {
+            var rowKeys = partitionGroup.Select(k => k.RowKey).Distinct(StringComparer.Ordinal).ToList();
+            for (var i = 0; i < rowKeys.Count; i += PartLookupChunkSize)
+            {
+                var conditions = string.Join(" or ", rowKeys
+                    .Skip(i)
+                    .Take(PartLookupChunkSize)
+                    .Select(rowKey => $"RowKey eq '{EscapeODataValue(rowKey)}'"));
+                var filter = $"PartitionKey eq '{EscapeODataValue(partitionGroup.Key)}' and ({conditions})";
+
+                foreach (var row in TableClient!.Query<TableEntity>(filter, null, RootMarkerProperties, CancellationToken))
+                {
+                    found[(row.PartitionKey, row.RowKey)] = row;
+                }
+            }
+        }
+
+        return found;
+    }
+
+    /// <summary>
+    /// Whether a root row carries any of the markers the large-entity write path
+    /// stamps on split entities.
+    /// </summary>
+    private static bool HasSplitMarkers(TableEntity root) =>
+        root.ContainsKey(EntitySplitter.SplitOverPropsKey) ||
+        root.ContainsKey(EntitySplitter.PartCountKey) ||
+        root.ContainsKey(EntitySplitter.OriginalEntityIdKey);
+
+    /// <summary>
+    /// Read one logical entity, reassembling it from its physical rows. Throws when
+    /// the entity does not exist or its rows cannot be reassembled.
+    /// </summary>
+    private TableEntity ReadLogicalEntity(string partitionKey, string rowKey)
+    {
+        // The prefix range is an index seek that catches the root row and every
+        // "{RowKey}-part{n}" row, but also unrelated rows sharing the prefix; filter
+        // to rows that belong to this entity before reassembling.
+        var filter = $"PartitionKey eq '{EscapeODataValue(partitionKey)}' and {BuildRowKeyPrefixClause(rowKey)}";
+        var rows = TableClient!.Query<TableEntity>(filter, null, null, CancellationToken)
+            .Where(row => row.RowKey == rowKey ||
+                (row.TryGetValue(EntitySplitter.OriginalEntityIdKey, out var id) && id?.ToString() == rowKey))
+            .ToList();
+
+        IncompleteEntityException? incomplete = null;
+        var entity = EntitySplitter.Reassemble(rows, null, ex => incomplete ??= ex)
+            .FirstOrDefault(e => e.RowKey == rowKey);
+
+        if (incomplete is not null)
+        {
+            throw incomplete;
+        }
+
+        return entity ?? throw new InvalidOperationException($"Cannot update entity with PartitionKey='{partitionKey}' and RowKey='{rowKey}' because it does not exist.");
     }
 
     /// <summary>

--- a/source/AzBobbyTables.Core/AzDataTableService.cs
+++ b/source/AzBobbyTables.Core/AzDataTableService.cs
@@ -518,6 +518,11 @@ public class AzDataTableService
     {
         ValidateTableClient();
 
+        if (operationType is not (OperationTypeEnum.UpdateMerge or OperationTypeEnum.UpdateReplace))
+        {
+            throw new ArgumentException($"Operation type {operationType} is not valid for updates of entities, use UpdateMerge or UpdateReplace!");
+        }
+
         try
         {
             var transactions = CreateTransactionList(entities);
@@ -1034,7 +1039,7 @@ public class AzDataTableService
         {
             if (operationType is not (OperationTypeEnum.UpdateMerge or OperationTypeEnum.UpdateReplace))
             {
-                throw new ArgumentException($"Operation type {operationType} is not valid for updates, use UpdateMerge or UpdateReplace!");
+                throw new ArgumentException($"Operation type {operationType} is not valid for updates of large entities, use UpdateMerge or UpdateReplace!");
             }
 
             // Deduplicate by entity identity, last one wins, same as the add path.

--- a/source/AzBobbyTables.PS/Cmdlets/UpdateAzDataTableLargeEntity.cs
+++ b/source/AzBobbyTables.PS/Cmdlets/UpdateAzDataTableLargeEntity.cs
@@ -1,0 +1,96 @@
+using PipeHow.AzBobbyTables.Core;
+using PipeHow.AzBobbyTables.Validation;
+using System;
+using System.Collections.Generic;
+using System.Management.Automation;
+
+namespace PipeHow.AzBobbyTables.Cmdlets;
+
+/// <summary>
+/// <para type="synopsis">Update one or more entities that already exist in an Azure Table, transparently handling entities that were split across multiple properties or rows by Add-AzDataTableLargeEntity.</para>
+/// </summary>
+[Cmdlet(VerbsData.Update, "AzDataTableLargeEntity")]
+public class UpdateAzDataTableLargeEntity : AzDataTableOperationCommand
+{
+    /// <summary>
+    /// <para type="description">The context used for the table, created with New-AzDataTableContext.</para>
+    /// </summary>
+    [Parameter(Mandatory = true)]
+    public AzDataTableContext Context { get; set; }
+
+    /// <summary>
+    /// <para type="description">The entities to update in the table.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, ValueFromPipeline = true)]
+    [ValidateNotNullOrEmpty()]
+    [ValidateEntity()]
+    public object[] Entity { get; set; }
+
+    /// <summary>
+    /// <para type="description">The type of operation to perform on the entities, defaults to UpdateMerge.</para>
+    /// </summary>
+    [Parameter()]
+    [ValidateSet("UpdateMerge", "UpdateReplace")]
+    public string OperationType { get; set; } = "UpdateMerge";
+
+    /// <summary>
+    /// <para type="description">Skips ETag validation and updates entity even if it has changed.</para>
+    /// </summary>
+    [Parameter()]
+    public SwitchParameter Force { get; set; }
+
+    /// <summary>
+    /// Entities gathered from the pipeline, submitted as one batch in EndProcessing.
+    /// </summary>
+    private readonly List<object> entities = new();
+
+    /// <summary>
+    /// The process step of the pipeline.
+    /// </summary>
+    protected override void ProcessRecord()
+    {
+        if (tableService is null)
+        {
+            WriteError(new ErrorRecord(new InvalidOperationException("Could not establish connection!"), "ConnectionError", ErrorCategory.ConnectionError, null));
+            return;
+        }
+
+        if (!Enum.TryParse<OperationTypeEnum>(OperationType, true, out _))
+        {
+            WriteError(new ErrorRecord(new ArgumentException($"Operation type {OperationType} is not valid!"), "InvalidOperationType", ErrorCategory.InvalidArgument, OperationType));
+            return;
+        }
+
+        // Collect rather than submit. Entity binds one pipeline record at a time, so submitting
+        // here sent a separate transaction per entity instead of batching up to 100.
+        entities.AddRange(Entity);
+    }
+
+    /// <summary>
+    /// Submit everything gathered from the pipeline as a single batched operation.
+    /// The operation type is re-parsed here rather than cached in a field: a field typed from
+    /// AzBobbyTables.Core forces that assembly to load while PowerShell inspects the cmdlet type,
+    /// which happens before OnImport registers the dependency load context.
+    /// </summary>
+    protected override void EndProcessing()
+    {
+        if (tableService is null || entities.Count == 0)
+        {
+            return;
+        }
+
+        if (!Enum.TryParse<OperationTypeEnum>(OperationType, true, out var operationTypeValue))
+        {
+            return;
+        }
+
+        try
+        {
+            tableService.UpdateLargeEntitiesInTable(entities, operationTypeValue, !Force.IsPresent);
+        }
+        catch (AzDataTableException ex)
+        {
+            WriteError(ex.ErrorRecord);
+        }
+    }
+}

--- a/source/AzBobbyTables.psd1
+++ b/source/AzBobbyTables.psd1
@@ -75,6 +75,7 @@ CmdletsToExport = @(
     'Remove-AzDataTableEntity'
     'Remove-AzDataTableLargeEntity'
     'Update-AzDataTableEntity'
+    'Update-AzDataTableLargeEntity'
     'New-AzDataTableContext'
     'Remove-AzDataTable'
     'New-AzDataTable'

--- a/tests/AzuriteIntegration.Tests.ps1
+++ b/tests/AzuriteIntegration.Tests.ps1
@@ -275,6 +275,17 @@ Describe 'Azurite Integration Tests' -Tag 'Integration' {
             (Get-AzDataTableEntity -Context $Context -Filter "Value1 eq 'Updated'").Count | Should -Be 0
         }
 
+        It 'cannot update entities that do not exist, even with -Force' {
+            # Regression guard: batched update actions without an If-Match header are
+            # treated by the service as insert-or-merge, so an entity without an ETag
+            # (or with -Force) was silently created instead of failing.
+            $Context = New-AzDataTableContext -TableName $TableName -ConnectionString $ConnectionString
+            $Ghost = @{ PartitionKey = 'nonexistent'; RowKey = 'nonexistent'; Value1 = 'ghost' }
+            { Update-AzDataTableEntity -Context $Context -Entity $Ghost -ErrorAction Stop } | Should -Throw
+            { Update-AzDataTableEntity -Context $Context -Entity $Ghost -Force -ErrorAction Stop } | Should -Throw
+            Get-AzDataTableEntity -Context $Context -Filter "PartitionKey eq 'nonexistent'" | Should -BeNullOrEmpty -Because 'a failed update must not create the row'
+        }
+
         It 'can get count of entities' {
             $Context = New-AzDataTableContext -TableName $TableName -ConnectionString $ConnectionString
             Get-AzDataTableEntity -Context $Context -Count | Should -BeExactly 4

--- a/tests/LargeEntityIntegration.Tests.ps1
+++ b/tests/LargeEntityIntegration.Tests.ps1
@@ -433,6 +433,171 @@ Describe 'Large Entity Integration Tests' -Tag 'Integration' {
         }
     }
 
+    Context 'updating' {
+        It 'fails on a missing entity and creates nothing' {
+            # An update must fail on a missing entity, never create one the way an
+            # upsert racing a concurrent delete would.
+            foreach ($operation in @('UpdateMerge', 'UpdateReplace')) {
+                { Update-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-missing'; RowKey = 'ghost'; Flag = $true } -OperationType $operation -ErrorAction Stop } | Should -Throw
+            }
+            @(Get-AzDataTableEntity -Context $Context -Filter "PartitionKey eq 'update-missing'") | Should -BeNullOrEmpty -Because 'a failed update must not leave a partial row behind'
+        }
+
+        It 'merges a scalar onto a plain entity' {
+            Add-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-plain'; RowKey = 'one'; A = 'kept' } -Force
+            Update-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-plain'; RowKey = 'one'; Flag = $true }
+
+            $result = Get-AzDataTableLargeEntity -Context $Context -Filter "PartitionKey eq 'update-plain'"
+            $result.A | Should -Be 'kept'
+            $result.Flag | Should -BeTrue
+        }
+
+        It 'merges a scalar onto a split entity without corrupting chunked properties' {
+            $data = New-PatternString -Length 100000 -Seed 'UM'
+            Add-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-split'; RowKey = 'one'; Data = $data; Plain = 'kept' } -Force
+
+            Update-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-split'; RowKey = 'one'; Flag = $true }
+
+            $result = Get-AzDataTableLargeEntity -Context $Context -Filter "PartitionKey eq 'update-split'"
+            ($result.Data -ceq $data) | Should -BeTrue -Because 'a merge must not lose or corrupt the chunked value'
+            $result.Plain | Should -Be 'kept'
+            $result.Flag | Should -BeTrue
+        }
+
+        It 'merges a small value over a previously chunked property' {
+            $data = New-PatternString -Length 100000 -Seed 'OW'
+            Add-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-overwrite'; RowKey = 'one'; Data = $data; Plain = 'kept' } -Force
+
+            Update-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-overwrite'; RowKey = 'one'; Data = 'small' }
+
+            $result = Get-AzDataTableLargeEntity -Context $Context -Filter "PartitionKey eq 'update-overwrite'"
+            $result.Data | Should -Be 'small' -Because 'the merged value must win over the stale chunks'
+            $result.Plain | Should -Be 'kept'
+
+            $raw = @(Get-AzDataTableEntity -Context $Context -Filter "PartitionKey eq 'update-overwrite'")
+            $raw[0].PSObject.Properties['Data_Part0'] | Should -BeNullOrEmpty -Because 'stale chunk properties must not survive the rewrite'
+        }
+
+        It 'merges an oversized value onto a plain entity' {
+            Add-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-grow'; RowKey = 'one'; A = 'kept' } -Force
+            $data = New-PatternString -Length 100000 -Seed 'GR'
+
+            Update-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-grow'; RowKey = 'one'; Data = $data }
+
+            $result = Get-AzDataTableLargeEntity -Context $Context -Filter "PartitionKey eq 'update-grow'"
+            ($result.Data -ceq $data) | Should -BeTrue
+            $result.A | Should -Be 'kept' -Because 'growing past the threshold must not drop the stored properties'
+        }
+
+        It 'merges onto a multi-row entity preserving properties on other rows' {
+            $v1 = @{ PartitionKey = 'update-multirow'; RowKey = 'one' }
+            1..30 | ForEach-Object { $v1["P$_"] = New-PatternString -Length 25000 -Seed "MR$_" }
+            Add-AzDataTableLargeEntity -Context $Context -Entity $v1 -Force
+
+            Update-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-multirow'; RowKey = 'one'; P1 = 'replaced' }
+
+            $result = Get-AzDataTableLargeEntity -Context $Context -Filter "PartitionKey eq 'update-multirow'"
+            $result.P1 | Should -Be 'replaced'
+            ($result.P30 -ceq $v1.P30) | Should -BeTrue -Because 'properties on other part rows must survive the merge'
+        }
+
+        It 'replaces a multi-row entity with a small version and removes stale part rows' {
+            $big = @{ PartitionKey = 'update-shrink'; RowKey = 'one' }
+            1..40 | ForEach-Object { $big["P$_"] = New-PatternString -Length 25000 -Seed "US$_" }
+            Add-AzDataTableLargeEntity -Context $Context -Entity $big -Force
+            @(Get-AzDataTableEntity -Context $Context -Filter "PartitionKey eq 'update-shrink'" -Property PartitionKey, RowKey).Count | Should -BeGreaterThan 1
+
+            Update-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-shrink'; RowKey = 'one'; V = 'tiny' } -OperationType UpdateReplace
+
+            @(Get-AzDataTableEntity -Context $Context -Filter "PartitionKey eq 'update-shrink'" -Property PartitionKey, RowKey).Count | Should -Be 1
+            $result = Get-AzDataTableLargeEntity -Context $Context -Filter "PartitionKey eq 'update-shrink'"
+            $result.V | Should -Be 'tiny'
+            $result.PSObject.Properties['P1'] | Should -BeNullOrEmpty -Because 'a replace must not carry stored properties forward'
+        }
+
+        It 'rejects an update of a changed entity without -Force' {
+            Add-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-etag'; RowKey = 'one'; V = 'original' } -Force
+
+            $stale = Get-AzDataTableLargeEntity -Context $Context -Filter "PartitionKey eq 'update-etag'"
+            Add-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-etag'; RowKey = 'one'; V = 'changed' } -Force
+
+            $stale.V = 'stale write'
+            { Update-AzDataTableLargeEntity -Context $Context -Entity $stale -ErrorAction Stop } | Should -Throw
+            (Get-AzDataTableLargeEntity -Context $Context -Filter "PartitionKey eq 'update-etag'").V | Should -Be 'changed'
+
+            { Update-AzDataTableLargeEntity -Context $Context -Entity $stale -Force } | Should -Not -Throw
+            (Get-AzDataTableLargeEntity -Context $Context -Filter "PartitionKey eq 'update-etag'").V | Should -Be 'stale write'
+        }
+
+        It 'removes stale chunk columns when a merged value needs fewer chunks' {
+            # 100000 chars split into 4 chunks; the replacement needs only 2. A merge
+            # that left Data_Part2/3 behind would corrupt the next reassembly.
+            Add-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-chunkshrink'; RowKey = 'one'; Data = (New-PatternString -Length 100000 -Seed 'C4') } -Force
+            $smaller = New-PatternString -Length 40000 -Seed 'C2'
+
+            Update-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-chunkshrink'; RowKey = 'one'; Data = $smaller }
+
+            $result = Get-AzDataTableLargeEntity -Context $Context -Filter "PartitionKey eq 'update-chunkshrink'"
+            ($result.Data -ceq $smaller) | Should -BeTrue
+
+            $raw = @(Get-AzDataTableEntity -Context $Context -Filter "PartitionKey eq 'update-chunkshrink'")
+            $raw.Count | Should -Be 1
+            $chunkNames = @($raw[0].PSObject.Properties.Name | Where-Object { $_ -match '^Data_Part\d+$' })
+            $manifest = $raw[0].SplitOverProps | ConvertFrom-Json
+            ($chunkNames | Sort-Object) | Should -Be (@($manifest.SplitHeaders) | Sort-Object) -Because 'every chunk column must be listed in the manifest and vice versa'
+            $raw[0].PSObject.Properties['Data_Part2'] | Should -BeNullOrEmpty -Because 'chunks of the larger old value must not survive'
+        }
+
+        It 'leaves no residue rows across alternating grow and shrink updates' {
+            Add-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-rounds'; RowKey = 'one'; Seed = 0 } -Force
+
+            $sizes = @(120000, 900, 1200000, 50000)
+            for ($i = 0; $i -lt $sizes.Count; $i++) {
+                $value = New-PatternString -Length $sizes[$i] -Seed "R$i"
+                Update-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-rounds'; RowKey = 'one'; Data = $value; Round = $i }
+
+                $result = Get-AzDataTableLargeEntity -Context $Context -Filter "PartitionKey eq 'update-rounds'"
+                ($result.Data -ceq $value) | Should -BeTrue -Because "round $i must read back exactly"
+                $result.Round | Should -Be $i
+            }
+
+            # The final 50k value fits one row: everything the 1.2M round created must be gone.
+            $raw = @(Get-AzDataTableEntity -Context $Context -Filter "PartitionKey eq 'update-rounds'" -Property PartitionKey, RowKey)
+            $raw.Count | Should -Be 1 -Because 'alternating grow/shrink must not accumulate part rows'
+        }
+
+        It 'does not bleed into entities whose RowKey shares a prefix' {
+            # ReadLogicalEntity fetches by RowKey range, which also matches unrelated
+            # neighbours like 'abc2' when updating 'abc'; they must be filtered out.
+            $abc = @{ PartitionKey = 'update-prefix'; RowKey = 'abc' }
+            1..30 | ForEach-Object { $abc["P$_"] = New-PatternString -Length 25000 -Seed "PX$_" }
+            Add-AzDataTableLargeEntity -Context $Context -Entity $abc -Force
+            Add-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-prefix'; RowKey = 'abc2'; V = 'neighbor' } -Force
+
+            { Update-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-prefix'; RowKey = 'ab'; X = 1 } -ErrorAction Stop } | Should -Throw -Because 'a prefix of an existing key is still a missing entity'
+            Update-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-prefix'; RowKey = 'abc2'; Touched = $true }
+
+            $split = @(Get-AzDataTableLargeEntity -Context $Context -Filter "PartitionKey eq 'update-prefix'") | Where-Object RowKey -EQ 'abc'
+            ($split.P30 -ceq $abc.P30) | Should -BeTrue
+            $split.PSObject.Properties['X'] | Should -BeNullOrEmpty
+            $split.PSObject.Properties['Touched'] | Should -BeNullOrEmpty -Because 'updating a neighbour must not touch the split entity'
+        }
+
+        It 'deduplicates duplicate keys in one call, last wins, through the split path' {
+            Add-AzDataTableLargeEntity -Context $Context -Entity @{ PartitionKey = 'update-dedup'; RowKey = 'one'; Data = 'seed' } -Force
+            $first = New-PatternString -Length 90000 -Seed 'D1'
+            $second = New-PatternString -Length 90000 -Seed 'D2'
+
+            Update-AzDataTableLargeEntity -Context $Context -Entity @(
+                @{ PartitionKey = 'update-dedup'; RowKey = 'one'; Data = $first }
+                @{ PartitionKey = 'update-dedup'; RowKey = 'one'; Data = $second }
+            )
+
+            $result = Get-AzDataTableLargeEntity -Context $Context -Filter "PartitionKey eq 'update-dedup'"
+            ($result.Data -ceq $second) | Should -BeTrue
+        }
+    }
+
     Context 'bulk behavior' {
         It 'deduplicates entities with the same keys in one call, last wins' {
             Add-AzDataTableLargeEntity -Context $Context -Force -Entity @(

--- a/tests/Update-AzDataTableLargeEntity.Tests.ps1
+++ b/tests/Update-AzDataTableLargeEntity.Tests.ps1
@@ -1,0 +1,81 @@
+BeforeDiscovery {
+    # Get command from current test file name
+    $Command = Get-Command ((Split-Path $PSCommandPath -Leaf) -replace '.Tests.ps1')
+    $ParameterTestCases += @(
+        @{
+            Command       = $Command
+            Name          = 'Context'
+            Type          = 'PipeHow.AzBobbyTables.AzDataTableContext'
+            ParameterSets = @(
+                @{ Name = '__AllParameterSets'; Mandatory = $true }
+            )
+        }
+        @{
+            Command       = $Command
+            Name          = 'Entity'
+            Type          = 'System.Object[]'
+            ParameterSets = @(
+                @{ Name = '__AllParameterSets'; Mandatory = $true }
+            )
+        }
+        @{
+            Command       = $Command
+            Name          = 'OperationType'
+            Type          = 'System.String'
+            ParameterSets = @(
+                @{ Name = '__AllParameterSets'; Mandatory = $false }
+            )
+        }
+        @{
+            Command       = $Command
+            Name          = 'Force'
+            Type          = 'System.Management.Automation.SwitchParameter'
+            ParameterSets = @(
+                @{ Name = '__AllParameterSets'; Mandatory = $false }
+            )
+        }
+        @{
+            Command       = $Command
+            Name          = 'MaxRetries'
+            Type          = 'int'
+            ParameterSets = @(
+                @{ Name = '__AllParameterSets'; Mandatory = $false }
+            )
+        }
+    )
+}
+
+Describe 'Update-AzDataTableLargeEntity' {
+    Context 'parameters' {
+
+        It 'only has expected parameters' -TestCases @{ Command = $Command ; Parameters = $ParameterTestCases.Name } {
+            $Command.Parameters.GetEnumerator() | Where-Object {
+                $_.Key -notin [System.Management.Automation.Cmdlet]::CommonParameters -and
+                $_.Key -notin $Parameters
+            } | Should -BeNullOrEmpty
+        }
+
+        It 'has parameter <Name> of type <Type>' -TestCases $ParameterTestCases {
+            $Command | Should -HaveParameter $Name -Type $Type
+        }
+
+        It 'has correct parameter sets for parameter <Name>' -TestCases $ParameterTestCases {
+            $Parameter = $Command.Parameters[$Name]
+            $Parameter.ParameterSets.Keys | Should -BeExactly $ParameterSets.Name
+        }
+
+        foreach ($ParameterTestCase in $ParameterTestCases) {
+            foreach ($ParameterSet in $ParameterTestCase.ParameterSets) {
+                It 'has parameter <ParameterName> set to mandatory <Mandatory> for parameter set <Name>' -TestCases @{
+                    Command       = $ParameterTestCase['Command']
+                    ParameterName = $ParameterTestCase['Name']
+                    Name          = $ParameterSet['Name']
+                    Mandatory     = $ParameterSet['Mandatory']
+                } {
+                    $Parameter = $Command.Parameters[$ParameterName]
+                    $Parameter.ParameterSets[$Name].IsMandatory | Should -Be $Mandatory
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

Adds a non-upserting update cmdlet to the large-entity family, and fixes a related bug where `Update-AzDataTableEntity` could silently create entities.

`Update-AzDataTableLargeEntity` updates entities that already exist, transparently handling entities that were split across multiple properties or rows by `Add-AzDataTableLargeEntity`. Entities that do not exist cause an error and are never created, unlike the upsert operation types of `Add-AzDataTableLargeEntity` — an upsert racing a concurrent delete recreates the row as a shell of just the written properties, while an update fails instead. `UpdateReplace` rewrites the logical entity and removes part rows the new version no longer uses. `UpdateMerge` merges a plain single-row entity in place, and reads, merges and rewrites entities that were split for size, since merging onto physical rows directly would corrupt reassembly. ETag validation applies to the entity's root row; `-Force` skips it but remains update-only.

While verifying the update-only guarantee, the same gap was found in the existing cmdlet: since the pipeline batching change in 3.6.1, `Update-AzDataTableEntity` submitted update actions without an `If-Match` header when called with `-Force` or with entities carrying no ETag, which the table service treats as insert-or-merge — updating a missing entity silently created it instead of failing.

### Added

- Added `Update-AzDataTableLargeEntity` for updating entities that exceed the Azure Table Storage size limits. Unlike the upsert operation types of `Add-AzDataTableLargeEntity`, entities that do not exist cause an error instead of being created. `UpdateReplace` rewrites the logical entity and removes part rows the new version no longer uses; `UpdateMerge` merges a plain single-row entity in place, and reads, merges and rewrites entities that were split for size, since merging onto physical rows directly would corrupt reassembly.

### Fixed

- `Update-AzDataTableEntity` no longer creates entities that do not exist when called with `-Force` or with entities that carry no ETag. Batched update actions were submitted without an `If-Match` header in those cases, which the table service treats as an insert-or-merge. Update actions now always carry `If-Match` (`*` when no ETag applies), matching the non-batched path and the documented behavior.

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or failed tests.
- [x] Markdown help added/updated.
- [x] Unit tests added/updated.